### PR TITLE
Small improvements to poller code.

### DIFF
--- a/include/bitcoin/node/poller.hpp
+++ b/include/bitcoin/node/poller.hpp
@@ -52,9 +52,10 @@ private:
     chain::blockchain& chain_;
 
     // Last hash from a block locator
-    hash_digest last_locator_begin_, last_hash_stop_;
+    hash_digest last_locator_begin_ = null_hash, last_hash_stop_ = null_hash;
+    network::channel* last_requested_node_ = nullptr;
     // Last hash from an inventory packet
-    hash_digest last_block_hash_;
+    hash_digest last_block_hash_ = null_hash;
 };
 
 } // namespace node

--- a/include/bitcoin/node/poller.hpp
+++ b/include/bitcoin/node/poller.hpp
@@ -48,7 +48,7 @@ private:
         const block_locator_type& locator,
         const hash_digest& hash_stop, network::channel_ptr node);
 
-    boost::asio::io_service::strand strand_;
+    async_strand strand_;
     chain::blockchain& chain_;
 
     // Last hash from a block locator

--- a/src/poller.cpp
+++ b/src/poller.cpp
@@ -29,8 +29,6 @@ using std::placeholders::_2;
 using boost::asio::io_service;
 
 poller::poller(threadpool& pool, chain::blockchain& chain)
-    last_locator_begin_(null_hash), last_hash_stop_(null_hash),
-    last_block_hash_(null_hash)
   : strand_(pool), chain_(chain)
 {
 }
@@ -61,7 +59,7 @@ void poller::initial_ask_blocks(const std::error_code& ec,
         return;
     }
     strand_.randomly_queue(
-        &poller::ask_blocks, this, ec, locator, node);
+        &poller::ask_blocks, this, ec, locator, null_hash, node);
 }
 
 void handle_send_packet(const std::error_code& ec)
@@ -134,7 +132,7 @@ void poller::handle_store(const std::error_code& ec, block_info info,
             // and next time do not download orphan block again.
             // Remember to remove from list once block is no longer orphan
             fetch_block_locator(chain_, strand_.wrap(
-                &poller::ask_blocks, this, _1, _2, node));
+                &poller::ask_blocks, this, _1, _2, block_hash, node));
             break;
 
         case block_status::rejected:
@@ -158,18 +156,22 @@ void poller::ask_blocks(const std::error_code& ec,
         log_error(LOG_POLLER) << "Ask for blocks: " << ec.message();
         return;
     }
-    if (last_locator_begin_ == locator.front() && last_hash_stop_ == hash_stop)
+    if (last_locator_begin_ == locator.front() &&
+        last_hash_stop_ == hash_stop && last_requested_node_ == node.get())
     {
         log_debug(LOG_POLLER) << "Skipping duplicate ask blocks: "
             << encode_hash(locator.front());
         return;
     }
+    // Send get_blocks request.
     get_blocks_type packet;
     packet.start_hashes = locator;
     packet.hash_stop = hash_stop;
     node->send(packet, std::bind(&handle_send_packet, _1));
+    // Update last values.
     last_locator_begin_ = locator.front();
     last_hash_stop_ = hash_stop;
+    last_requested_node_ = node.get();
 }
 
 } // namespace node

--- a/src/poller.cpp
+++ b/src/poller.cpp
@@ -29,9 +29,9 @@ using std::placeholders::_2;
 using boost::asio::io_service;
 
 poller::poller(threadpool& pool, chain::blockchain& chain)
-  : strand_(pool.service()), chain_(chain),
     last_locator_begin_(null_hash), last_hash_stop_(null_hash),
     last_block_hash_(null_hash)
+  : strand_(pool), chain_(chain)
 {
 }
 
@@ -45,8 +45,7 @@ void poller::query(network::channel_ptr node)
 void poller::monitor(network::channel_ptr node)
 {
     node->subscribe_inventory(
-        strand_.wrap(std::bind(&poller::receive_inv,
-            this, _1, _2, node)));
+        strand_.wrap(&poller::receive_inv, this, _1, _2, node));
     node->subscribe_block(
         std::bind(&poller::receive_block,
             this, _1, _2, node));
@@ -61,8 +60,8 @@ void poller::initial_ask_blocks(const std::error_code& ec,
             << "Fetching initial block locator: " << ec.message();
         return;
     }
-    strand_.dispatch(std::bind(&poller::ask_blocks,
-        this, ec, locator, null_hash, node));
+    strand_.randomly_queue(
+        &poller::ask_blocks, this, ec, locator, node);
 }
 
 void handle_send_packet(const std::error_code& ec)
@@ -96,8 +95,7 @@ void poller::receive_inv(const std::error_code& ec,
         node->send(getdata, handle_send_packet);
     }
     node->subscribe_inventory(
-        strand_.wrap(std::bind(&poller::receive_inv,
-            this, _1, _2, node)));
+        strand_.wrap(&poller::receive_inv, this, _1, _2, node));
 }
 
 void poller::receive_block(const std::error_code& ec,
@@ -109,7 +107,7 @@ void poller::receive_block(const std::error_code& ec,
         return;
     }
     chain_.store(blk,
-        std::bind(&poller::handle_store,
+        strand_.wrap(&poller::handle_store,
             this, _1, _2, hash_block_header(blk.header), node));
     node->subscribe_block(
         std::bind(&poller::receive_block,
@@ -135,9 +133,8 @@ void poller::handle_store(const std::error_code& ec, block_info info,
             // TODO: Make more efficient by storing block hash
             // and next time do not download orphan block again.
             // Remember to remove from list once block is no longer orphan
-            fetch_block_locator(chain_,
-                strand_.wrap(std::bind(&poller::ask_blocks,
-                    this, _1, _2, block_hash, node)));
+            fetch_block_locator(chain_, strand_.wrap(
+                &poller::ask_blocks, this, _1, _2, node));
             break;
 
         case block_status::rejected:

--- a/src/session.cpp
+++ b/src/session.cpp
@@ -47,13 +47,6 @@ void session::start(completion_handler handle_complete)
 {
     protocol_.start(handle_complete);
     protocol_.subscribe_channel(
-        [this](const std::error_code& ec, network::channel_ptr node)
-        {
-            BITCOIN_ASSERT(!ec || ec == error::service_stopped);
-            if (!ec)
-                poll_.query(node);
-        });
-    protocol_.subscribe_channel(
         std::bind(&session::new_channel, this, _1, _2));
     chain_.fetch_last_height(
         std::bind(&network::handshake::set_start_height,
@@ -84,6 +77,7 @@ void session::new_channel(const std::error_code& ec, network::channel_ptr node)
     // block
     protocol_.subscribe_channel(
         std::bind(&session::new_channel, this, _1, _2));
+    poll_.query(node);
     poll_.monitor(node);
 }
 


### PR DESCRIPTION
First commit simply updates the code to use the newer async_strand which is cleaner.

The main part of this code though is to improve the poller code:
* Every new node is queried for new blocks by default. [ poll_.query(node) ]
* Make code to drop duplicate "getblocks" requests more stricter- only drop duplicates sent to the same node. [ last_requested_node_ == node.get() ]