### PR TITLE
Implement dynamic allocation for parallel initial block download.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,10 +36,13 @@ src_libbitcoin_node_la_CPPFLAGS = -I${srcdir}/include -DSYSCONFDIR=\"${sysconfdi
 src_libbitcoin_node_la_LIBADD = ${bitcoin_blockchain_LIBS} ${bitcoin_network_LIBS}
 src_libbitcoin_node_la_SOURCES = \
     src/configuration.cpp \
+    src/hash_queue.cpp \
     src/p2p_node.cpp \
     src/parser.cpp \
     src/protocol_block_sync.cpp \
     src/protocol_header_sync.cpp \
+    src/reservation.cpp \
+    src/reservations.cpp \
     src/session_block_sync.cpp \
     src/session_header_sync.cpp \
     src/settings.cpp
@@ -54,8 +57,11 @@ check_PROGRAMS = test/libbitcoin_node_test
 test_libbitcoin_node_test_CPPFLAGS = -I${srcdir}/include ${bitcoin_blockchain_CPPFLAGS} ${bitcoin_network_CPPFLAGS}
 test_libbitcoin_node_test_LDADD = src/libbitcoin-node.la ${boost_unit_test_framework_LIBS} ${bitcoin_blockchain_LIBS} ${bitcoin_network_LIBS}
 test_libbitcoin_node_test_SOURCES = \
+    test/hash_queue.cpp \
     test/main.cpp \
-    test/node.cpp
+    test/node.cpp \
+    test/reservation.cpp \
+    test/reservations.cpp
 
 endif WITH_TESTS
 
@@ -83,10 +89,13 @@ include_bitcoin_nodedir = ${includedir}/bitcoin/node
 include_bitcoin_node_HEADERS = \
     include/bitcoin/node/configuration.hpp \
     include/bitcoin/node/define.hpp \
+    include/bitcoin/node/hash_queue.hpp \
     include/bitcoin/node/p2p_node.hpp \
     include/bitcoin/node/parser.hpp \
     include/bitcoin/node/protocol_block_sync.hpp \
     include/bitcoin/node/protocol_header_sync.hpp \
+    include/bitcoin/node/reservation.hpp \
+    include/bitcoin/node/reservations.hpp \
     include/bitcoin/node/session_block_sync.hpp \
     include/bitcoin/node/session_header_sync.hpp \
     include/bitcoin/node/settings.hpp \

--- a/builds/msvc/vs2013/libbitcoin-node-test/libbitcoin-node-test.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin-node-test/libbitcoin-node-test.vcxproj
@@ -65,8 +65,11 @@
     <Import Project="$(ProjectDir)$(ProjectName).props" />
   </ImportGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\..\test\hash_queue.cpp" />
     <ClCompile Include="..\..\..\..\test\main.cpp" />
     <ClCompile Include="..\..\..\..\test\node.cpp" />
+    <ClCompile Include="..\..\..\..\test\reservation.cpp" />
+    <ClCompile Include="..\..\..\..\test\reservations.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/builds/msvc/vs2013/libbitcoin-node-test/libbitcoin-node-test.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin-node-test/libbitcoin-node-test.vcxproj.filters
@@ -15,5 +15,14 @@
     <ClCompile Include="..\..\..\..\test\node.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\test\reservation.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\test\reservations.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\test\hash_queue.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/builds/msvc/vs2013/libbitcoin-node/libbitcoin-node.vcxproj
+++ b/builds/msvc/vs2013/libbitcoin-node/libbitcoin-node.vcxproj
@@ -71,10 +71,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\..\src\hash_queue.cpp" />
+    <ClCompile Include="..\..\..\..\src\reservation.cpp" />
     <ClCompile Include="..\..\..\..\src\configuration.cpp" />
     <ClCompile Include="..\..\..\..\src\p2p_node.cpp" />
     <ClCompile Include="..\..\..\..\src\protocol_block_sync.cpp" />
     <ClCompile Include="..\..\..\..\src\protocol_header_sync.cpp" />
+    <ClCompile Include="..\..\..\..\src\reservations.cpp" />
     <ClCompile Include="..\..\..\..\src\session_block_sync.cpp" />
     <ClCompile Include="..\..\..\..\src\session_header_sync.cpp" />
     <ClCompile Include="..\..\..\..\src\parser.cpp" />
@@ -82,12 +85,15 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\bitcoin\node.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\node\hash_queue.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\node\reservation.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\configuration.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\define.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\p2p_node.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\parser.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\protocol_block_sync.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\protocol_header_sync.hpp" />
+    <ClInclude Include="..\..\..\..\include\bitcoin\node\reservations.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\session_block_sync.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\session_header_sync.hpp" />
     <ClInclude Include="..\..\..\..\include\bitcoin\node\settings.hpp" />

--- a/builds/msvc/vs2013/libbitcoin-node/libbitcoin-node.vcxproj.filters
+++ b/builds/msvc/vs2013/libbitcoin-node/libbitcoin-node.vcxproj.filters
@@ -42,6 +42,15 @@
     <ClCompile Include="..\..\..\..\src\configuration.cpp">
       <Filter>src</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\..\..\src\reservation.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\reservations.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\..\src\hash_queue.cpp">
+      <Filter>src</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\..\..\include\bitcoin\node.hpp">
@@ -75,6 +84,15 @@
       <Filter>include\bitcoin\node</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\..\include\bitcoin\node\parser.hpp">
+      <Filter>include\bitcoin\node</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\node\reservation.hpp">
+      <Filter>include\bitcoin\node</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\node\reservations.hpp">
+      <Filter>include\bitcoin\node</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\..\include\bitcoin\node\hash_queue.hpp">
       <Filter>include\bitcoin\node</Filter>
     </ClInclude>
   </ItemGroup>

--- a/configure.ac
+++ b/configure.ac
@@ -220,6 +220,12 @@ AS_CASE([${CC}], [*gcc*],
     [AX_CHECK_COMPILE_FLAG([-Wno-deprecated-declarations],
         [CXXFLAGS="$CXXFLAGS -Wno-deprecated-declarations"])])
 
+# Clean up boost 1.55 headers. Enabled in clang only.
+#------------------------------------------------------------------------------
+AS_CASE([${CC}], [*clang*],
+    [AX_CHECK_COMPILE_FLAG([-Wno-redeclared-class-member],
+        [CXXFLAGS="$CXXFLAGS -Wno-redeclared-class-member"])])
+
 # Protect stack.
 #------------------------------------------------------------------------------
 AS_CASE([${CC}], [*],

--- a/data/bn.cfg
+++ b/data/bn.cfg
@@ -7,8 +7,8 @@ threads = 50
 identifier = 3652501241
 # The port for incoming connections, defaults to 8333 (use 18333 for testnet).
 inbound_port = 8333
-# The target number of total network connections, defaults to 16.
-connection_limit = 16
+# The target number of incoming network connections, defaults to 8.
+inbound_connections = 8
 # The target number of outgoing network connections, defaults to 8.
 outbound_connections = 8
 # The attempt limit for manual connection establishment, defaults to 0 (forever).
@@ -19,8 +19,6 @@ connect_batch_size = 5
 connect_timeout_seconds = 5
 # The time limit to complete the connection handshake, defaults to 30.
 channel_handshake_seconds = 30
-# The polling interval for initial block download, defaults to 1.
-channel_poll_seconds = 1
 # The time between ping messages, defaults to 5.
 channel_heartbeat_minutes = 5
 # The inactivity time limit for any connection, defaults to 30.
@@ -105,9 +103,7 @@ checkpoint = 0000000000000000086672a8c97ad666f89cf04736951791150015419810d586:36
 #checkpoint = 000000000000624f06c69d3a9fe8d25e0a9030569128d63ad1b704bbb3059a16:600000
 
 [node]
-# The minimum block byte rate required from a peer during block sync, defaults to 100000.
-block_bytes_per_second = 100000
-# The minimum header rate required from a peer during header sync, defaults to 10000.
-headers_per_second = 10000
+# The maximum number of connections for initial block download, defaults to 8.
+download_connections = 8
 # Persistent host:port to augment discovered hosts, multiple entries allowed.
 # peer = obelisk.airbitz.co:8333

--- a/include/bitcoin/node.hpp
+++ b/include/bitcoin/node.hpp
@@ -18,10 +18,13 @@
 #include <bitcoin/network.hpp>
 #include <bitcoin/node/configuration.hpp>
 #include <bitcoin/node/define.hpp>
+#include <bitcoin/node/hash_queue.hpp>
 #include <bitcoin/node/p2p_node.hpp>
 #include <bitcoin/node/parser.hpp>
 #include <bitcoin/node/protocol_block_sync.hpp>
 #include <bitcoin/node/protocol_header_sync.hpp>
+#include <bitcoin/node/reservation.hpp>
+#include <bitcoin/node/reservations.hpp>
 #include <bitcoin/node/session_block_sync.hpp>
 #include <bitcoin/node/session_header_sync.hpp>
 #include <bitcoin/node/settings.hpp>

--- a/include/bitcoin/node/hash_queue.hpp
+++ b/include/bitcoin/node/hash_queue.hpp
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2011-2016 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_HASH_QUEUE_HPP
+#define LIBBITCOIN_HASH_QUEUE_HPP
+
+#include <cstddef>
+#include <vector>
+#include <bitcoin/bitcoin.hpp>
+#include <bitcoin/node/define.hpp>
+
+namespace libbitcoin {
+namespace node {
+
+// A smart queue for chaining blockchain header hashes, thread safe.
+class BCN_API hash_queue
+{
+public:
+    /// Construct a block hash list with specified height offset.
+    hash_queue(const config::checkpoint::list& checkpoints);
+
+    /// True if the list is empty.
+    bool empty() const;
+
+    /// The number of elements.
+    size_t size() const;
+
+    /// The height of the first element.
+    size_t first_height() const;
+
+    /// The height of the last element.
+    size_t last_height() const;
+
+    /// The last hash in the list or null_hash if none.
+    hash_digest last_hash() const;
+
+    /// Remove the first count of hashes, return true if satisfied.
+    bool pop(size_t count=1);
+
+    /// Obtain and remove the first hash.
+    bool pop(hash_digest& out_hash, size_t& out_height);
+
+    /// Place a hash on the queue.
+    void push(const hash_digest& hash);
+
+    /// Merge the hashes in the message with those in the queue.
+    bool push(message::headers::ptr message);
+
+    /// Reclaim unused head space.
+    void shrink();
+
+    /// Clear the queue and populate one hash at the given height.
+    void initialize(const hash_digest& hash, size_t height);
+
+private:
+    // True if the queue is empty (not locked).
+    bool is_empty() const;
+
+    // The number of hashes in the queue (not locked).
+    size_t get_size() const;
+
+    // The last hash in the list or null_hash if none (not locked).
+    size_t last() const;
+
+    // Roll back the list to the last checkpoint.
+    void rollback();
+
+    // Merge a set of block hashes to the list, validating linkage.
+    bool merge(message::headers::ptr message);
+
+    // Determine if the hash violates a checkpoint.
+    bool check(const hash_digest& hash, size_t height) const;
+
+    // Determine if the hash is linked to the give (preceding) header.
+    bool linked(const chain::header& header, const hash_digest& hash) const;
+
+    // The list of checkpoints that determines the sync range.
+    const config::checkpoint::list& checkpoints_;
+
+    // protected by mutex.
+    size_t height_;
+    hash_list list_;
+    hash_list::iterator head_;
+    mutable upgrade_mutex mutex_;
+};
+
+} // namespace node
+} // namespace libbitcoin
+
+#endif
+

--- a/include/bitcoin/node/p2p_node.hpp
+++ b/include/bitcoin/node/p2p_node.hpp
@@ -26,6 +26,7 @@
 #include <bitcoin/network.hpp>
 #include <bitcoin/node/configuration.hpp>
 #include <bitcoin/node/define.hpp>
+#include <bitcoin/node/hash_queue.hpp>
 
 namespace libbitcoin {
 namespace node {
@@ -90,16 +91,16 @@ private:
     void handle_blockchain_start(const code& ec, result_handler handler);
     void handle_fetch_header(const code& ec, const chain::header& block_header,
         size_t block_height, result_handler handler);
-    void handle_headers_synchronized(const code& ec, size_t block_height,
-        result_handler handler);
-    void handle_blocks_synchronized(const code& ec, size_t start_height,
-        result_handler handler);
+    void handle_headers_synchronized(const code& ec, result_handler handler);
+    void handle_blocks_synchronized(const code& ec, result_handler handler);
 
-    // This is guarded by the non-restartable node constraint.
-    hash_list hashes_;
+    // This is thread safe and guarded by the non-restartable node constraint.
+    hash_queue hashes_;
+
+    // This is thread safe.
+    blockchain::block_chain_impl blockchain_;
 
     const settings& settings_;
-    blockchain::block_chain_impl blockchain_;
 };
 
 } // namspace node

--- a/include/bitcoin/node/protocol_block_sync.hpp
+++ b/include/bitcoin/node/protocol_block_sync.hpp
@@ -30,28 +30,18 @@
 namespace libbitcoin {
 namespace node {
         
-/**
- * Blocks sync protocol.
- */
+/// Blocks sync protocol, thread safe.
 class BCN_API protocol_block_sync
   : public network::protocol_timer, public track<protocol_block_sync>
 {
 public:
     typedef std::shared_ptr<protocol_block_sync> ptr;
 
-    /**
-     * Construct a block sync protocol instance.
-     * @param[in]  network  The network interface.
-     * @param[in]  channel  The channel on which to start the protocol.
-     * @param[in]  row      The channel row in the reservation table.
-     */
+    /// Construct a block sync protocol instance.
     protocol_block_sync(network::p2p& network, network::channel::ptr channel,
         reservation::ptr row);
 
-    /**
-     * Start the protocol.
-     * @param[in]  handler  The handler to call upon sync completion.
-     */
+    /// Start the protocol.
     void start(event_handler handler);
 
 private:

--- a/include/bitcoin/node/protocol_block_sync.hpp
+++ b/include/bitcoin/node/protocol_block_sync.hpp
@@ -20,15 +20,12 @@
 #ifndef LIBBITCOIN_NODE_PROTOCOL_BLOCK_SYNC_HPP
 #define LIBBITCOIN_NODE_PROTOCOL_BLOCK_SYNC_HPP
 
-#include <atomic>
 #include <cstddef>
-#include <cstdint>
 #include <memory>
-#include <vector>
 #include <bitcoin/blockchain.hpp>
 #include <bitcoin/network.hpp>
-#include <bitcoin/node/configuration.hpp>
 #include <bitcoin/node/define.hpp>
+#include <bitcoin/node/reservation.hpp>
 
 namespace libbitcoin {
 namespace node {
@@ -44,53 +41,28 @@ public:
 
     /**
      * Construct a block sync protocol instance.
-     * @param[in]  network       The network interface.
-     * @param[in]  channel       The channel on which to start the protocol.
-     * @param[in]  first_height  The height of the first block in hashes.
-     * @param[in]  start_height  The height of the first block in sync range.
-     * @param[in]  offset        The offset of this sync partition.
-     * @param[in]  minimum_rate  The minimum sync rate in bytes per second.
-     * @param[in]  hashes        The ordered set of block hashes to sync.
-     * @param[in]  blockchain    The blockchain interface.
+     * @param[in]  network  The network interface.
+     * @param[in]  channel  The channel on which to start the protocol.
+     * @param[in]  row      The channel row in the reservation table.
      */
     protocol_block_sync(network::p2p& network, network::channel::ptr channel,
-        size_t first_height, size_t start_height, size_t offset,
-        uint32_t minimum_rate, const hash_list& hashes,
-        blockchain::block_chain& chain);
+        reservation::ptr row);
 
     /**
      * Start the protocol.
      * @param[in]  handler  The handler to call upon sync completion.
      */
-    void start(count_handler handler);
+    void start(event_handler handler);
 
 private:
-    size_t current_height() const;
-    size_t current_rate() const;
-    const hash_digest& current_hash() const;
-    message::get_data build_get_data() const;
-    bool next_block(const message::block& message);
-
-    void send_get_blocks(event_handler complete);
+    void send_get_blocks(event_handler complete, bool reset);
     void handle_send(const code& ec, event_handler complete);
     void handle_event(const code& ec, event_handler complete);
-    void blocks_complete(const code& ec, count_handler handler);
+    void blocks_complete(const code& ec, event_handler handler);
     bool handle_receive(const code& ec, message::block::ptr message,
         event_handler complete);
 
-    // This is guarded by protocol_timer/deadline contract (exactly one call).
-    size_t byte_count_;
-
-    // This is write-guarded by the block message subscriber strand.
-    std::atomic<size_t> index_;
-
-    const size_t offset_;
-    const size_t channel_;
-    const size_t first_height_;
-    const size_t start_height_;
-    const uint32_t minimum_rate_;
-    const hash_list& hashes_;
-    blockchain::block_chain& blockchain_;
+    reservation::ptr reservation_;
 };
 
 } // namespace network

--- a/include/bitcoin/node/protocol_header_sync.hpp
+++ b/include/bitcoin/node/protocol_header_sync.hpp
@@ -32,31 +32,19 @@
 namespace libbitcoin {
 namespace node {
         
-/**
- * Headers sync protocol.
- */
+/// Headers sync protocol, thread safe.
 class BCN_API protocol_header_sync
   : public network::protocol_timer, public track<protocol_header_sync>
 {
 public:
     typedef std::shared_ptr<protocol_header_sync> ptr;
 
-    /**
-     * Construct a header sync protocol instance.
-     * @param[in]  network       The network interface.
-     * @param[in]  channel       The channel on which to start the protocol.
-     * @param[in]  hashes        The ordered set of block hashes when cmplete.
-     * @param[in]  minimum_rate  The minimum sync rate in headers per second.
-     * @param[in]  checkpoints   The ordered blockchain checkpoints.
-     */
+    /// Construct a header sync protocol instance.
     protocol_header_sync(network::p2p& network, network::channel::ptr channel,
         hash_queue& hashes, uint32_t minimum_rate,
         const config::checkpoint::list& checkpoints);
 
-    /**
-     * Start the protocol.
-     * @param[in]  handler  The handler to call upon sync completion.
-     */
+    /// Start the protocol.
     void start(event_handler handler);
 
 private:

--- a/include/bitcoin/node/protocol_header_sync.hpp
+++ b/include/bitcoin/node/protocol_header_sync.hpp
@@ -27,6 +27,7 @@
 #include <bitcoin/network.hpp>
 #include <bitcoin/node/configuration.hpp>
 #include <bitcoin/node/define.hpp>
+#include <bitcoin/node/hash_queue.hpp>
 
 namespace libbitcoin {
 namespace node {
@@ -44,13 +45,12 @@ public:
      * Construct a header sync protocol instance.
      * @param[in]  network       The network interface.
      * @param[in]  channel       The channel on which to start the protocol.
-     * @param[in]  minimum_rate  The minimum sync rate in headers per second.
-     * @param[in]  first_height  The height of the first entry in headers.
      * @param[in]  hashes        The ordered set of block hashes when cmplete.
+     * @param[in]  minimum_rate  The minimum sync rate in headers per second.
      * @param[in]  checkpoints   The ordered blockchain checkpoints.
      */
     protocol_header_sync(network::p2p& network, network::channel::ptr channel,
-        uint32_t minimum_rate, size_t first_height, hash_list& hashes,
+        hash_queue& hashes, uint32_t minimum_rate,
         const config::checkpoint::list& checkpoints);
 
     /**
@@ -60,17 +60,11 @@ public:
     void start(event_handler handler);
 
 private:
-    static size_t last_height(size_t first_height, hash_list& headers,
+    static size_t final_height(hash_queue& headers,
         const config::checkpoint::list& checkpoints);
 
-    size_t current_height() const;
-    size_t current_rate() const;
-
-    void rollback();
-    bool merge_headers(message::headers::ptr message);
-    bool checks(const hash_digest& hash, size_t height) const;
-    bool linked(const chain::header& header, const hash_digest& hash) const;
-    bool proof_of_work(const chain::header& header, size_t height) const;
+    size_t sync_rate() const;
+    size_t next_height() const;
 
     void send_get_headers(event_handler complete);
     void handle_send(const code& ec, event_handler complete);
@@ -79,16 +73,15 @@ private:
     bool handle_receive(const code& ec, message::headers::ptr message,
         event_handler complete);
 
-    // This is write-guarded by the header message subscriber strand.
-    hash_list& hashes_;
+    // Thread safe and guarded by sequential header sync.
+    hash_queue& hashes_;
 
     // This is guarded by protocol_timer/deadline contract (exactly one call).
     size_t current_second_;
 
     const uint32_t minimum_rate_;
     const size_t start_size_;
-    const size_t first_height_;
-    const size_t last_height_;
+    const size_t final_height_;
     const config::checkpoint::list& checkpoints_;
 };
 

--- a/include/bitcoin/node/reservation.hpp
+++ b/include/bitcoin/node/reservation.hpp
@@ -61,7 +61,7 @@ public:
     bool expired() const;
 
     /// Sets the idle state to true. Call when channel is stopped.
-    void reservation::set_idle();
+    void set_idle();
 
     /// True if the reservation is not applied to a channel.
     bool idle() const;

--- a/include/bitcoin/node/reservation.hpp
+++ b/include/bitcoin/node/reservation.hpp
@@ -37,7 +37,7 @@ namespace node {
 
 class reservations;
 
-// Thread safe.
+// Class to manage hashes during sync, thread safe.
 class BCN_API reservation
   : public enable_shared_from_base<reservation>
 {
@@ -46,7 +46,7 @@ public:
     typedef std::vector<reservation::ptr> list;
 
     /// Construct a block reservation with the specified identifier.
-    reservation(reservations& reservations, size_t slot, float rate_factor);
+    reservation(reservations& reservations, size_t slot);
 
     /// The sequential identifier of this reservation.
     size_t slot() const;
@@ -97,6 +97,7 @@ private:
         std::chrono::system_clock::duration import;
         std::chrono::system_clock::time_point time;
     } import_record;
+
     typedef std::vector<import_record> rate_history;
 
     // A bidirection map is used for efficient hash and height retrieval.
@@ -116,9 +117,6 @@ private:
 
     // The sequential identifier of the reservation instance.
     const size_t slot_;
-
-    // The allowable amount of standard deviation from the norm.
-    const float factor_;
 
     // Thread safe.
     std::atomic<bool> idle_;

--- a/include/bitcoin/node/reservation.hpp
+++ b/include/bitcoin/node/reservation.hpp
@@ -103,7 +103,7 @@ private:
     // A bidirection map is used for efficient hash and height retrieval.
     typedef boost::bimaps::bimap<
         boost::bimaps::unordered_set_of<hash_digest>,
-        boost::bimaps::set_of<uint32_t >> hash_heights;
+        boost::bimaps::set_of<uint32_t>> hash_heights;
 
     // Return rate history to startup state.
     void clear_rate_history();

--- a/include/bitcoin/node/reservation.hpp
+++ b/include/bitcoin/node/reservation.hpp
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2011-2016 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_NODE_RESERVATION_HPP
+#define LIBBITCOIN_NODE_RESERVATION_HPP
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+#include <boost/bimap.hpp>
+#include <boost/bimap/set_of.hpp>
+#include <boost/bimap/unordered_set_of.hpp>
+#include <bitcoin/blockchain.hpp>
+#include <bitcoin/node/define.hpp>
+
+namespace libbitcoin {
+namespace node {
+
+class reservations;
+
+// Thread safe.
+class BCN_API reservation
+  : public enable_shared_from_base<reservation>
+{
+public:
+    typedef std::shared_ptr<reservation> ptr;
+    typedef std::vector<reservation::ptr> list;
+
+    /// Construct a block reservation with the specified identifier.
+    reservation(reservations& reservations, size_t slot, float rate_factor);
+
+    /// The sequential identifier of this reservation.
+    size_t slot() const;
+
+    /// True if there are any outstanding blocks.
+    bool empty() const;
+
+    /// The number of outstanding blocks.
+    size_t size() const;
+
+    /// True if block import rate was more than one standard deviation low.
+    bool expired() const;
+
+    /// Sets the idle state to true. Call when channel is stopped.
+    void reservation::set_idle();
+
+    /// True if the reservation is not applied to a channel.
+    bool idle() const;
+
+    /// The current cached average block import rate excluding import time.
+    float rate() const;
+
+    /// The block data request message for the outstanding block hashes.
+    /// Set reset if the preceding request was unsuccessful or discarded.
+    message::get_data request(bool reset);
+
+    /// Add the block hash to the reservation.
+    void insert(const hash_digest& hash, size_t height);
+
+    /// Add to the blockchain, with height determined by the reservation.
+    void import(chain::block::ptr block);
+
+    /// Determine if the reservation was partitioned and reset partition flag.
+    bool partitioned();
+
+    /// Move half of the reservation to the specified reservation.
+    void partition(reservation::ptr minimal);
+
+protected:
+
+    // Isolation of side effect to enable unit testing.
+    virtual std::chrono::system_clock::time_point current_time() const;
+
+private:
+    typedef struct
+    {
+        size_t size;
+        std::chrono::system_clock::duration import;
+        std::chrono::system_clock::time_point time;
+    } import_record;
+    typedef std::vector<import_record> rate_history;
+
+    // A bidirection map is used for efficient hash and height retrieval.
+    typedef boost::bimaps::bimap<
+        boost::bimaps::unordered_set_of<hash_digest>,
+        boost::bimaps::set_of<uint32_t >> hash_heights;
+
+    // Return rate history to startup state.
+    void clear_rate_history();
+
+    // Get the height of the block hash, remove and return true if it is found.
+    bool find_height_and_erase(const hash_digest& hash, uint32_t& out_height);
+
+    // Update rate history to reflect an additional block of the given size.
+    void update_rate_history(size_t size,
+        const std::chrono::system_clock::duration& cost);
+
+    // The sequential identifier of the reservation instance.
+    const size_t slot_;
+
+    // The allowable amount of standard deviation from the norm.
+    const float factor_;
+
+    // Thread safe.
+    std::atomic<bool> idle_;
+    std::atomic<float> rate_;
+    std::atomic<float> adjusted_rate_;
+    reservations& reservations_;
+
+    // Protected by history mutex.
+    rate_history history_;
+    mutable upgrade_mutex history_mutex_;
+
+    // Protected by hash mutex.
+    bool pending_;
+    bool partitioned_;
+    hash_heights heights_;
+    mutable upgrade_mutex hash_mutex_;
+};
+
+} // namespace node
+} // namespace libbitcoin
+
+#endif
+

--- a/include/bitcoin/node/reservations.hpp
+++ b/include/bitcoin/node/reservations.hpp
@@ -1,0 +1,97 @@
+/**
+ * Copyright (c) 2011-2016 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef LIBBITCOIN_NODE_RESERVATIONS_HPP
+#define LIBBITCOIN_NODE_RESERVATIONS_HPP
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+#include <bitcoin/blockchain.hpp>
+#include <bitcoin/node/define.hpp>
+#include <bitcoin/node/hash_queue.hpp>
+#include <bitcoin/node/reservation.hpp>
+#include <bitcoin/node/settings.hpp>
+
+namespace libbitcoin {
+namespace node {
+
+// Thread safe.
+class BCN_API reservations
+{
+public:
+    typedef struct
+    {
+        size_t active_count;
+        float arithmentic_mean;
+        float standard_deviation;
+    } rate_summary;
+    typedef std::shared_ptr<reservations> ptr;
+
+    /// Construct a reservation table of reservations, allocating hashes evenly
+    // among the rows up to the limit of a single get headers p2p request.
+    reservations(hash_queue& hashes, blockchain::block_chain& chain,
+        const settings& settings);
+
+    /// The averate and standard deviation of block import rates.
+    rate_summary rates() const;
+
+    /// Return a copy of the reservation table.
+    reservation::list table() const;
+
+    /// Import the given block to the blockchain at the specified height.
+    bool import(chain::block::ptr block, size_t height);
+
+    /// Populate a starved row by taking half of the hashes from a weak row.
+    void populate(reservation::ptr minimal);
+
+    /// Remove the row from the reservation table if found.
+    void remove(reservation::ptr row);
+
+private:
+    // Create the specified number of reservations and distribute hashes.
+    void initialize(size_t size);
+
+    // Find the reservation with the most hashes.
+    reservation::ptr find_maximal();
+
+    // Move half of the maximal reservation to the specified reservation.
+    void partition(reservation::ptr minimal);
+
+    // Move the maximum unreserved hashes to the specified reservation.
+    bool reserve(reservation::ptr minimal);
+
+    // Thread safe.
+    hash_queue& hashes_;
+    blockchain::block_chain& blockchain_;
+
+    // Protected by mutex.
+    reservation::list table_;
+    mutable upgrade_mutex mutex_;
+
+    // Settings.
+    const float factor_;
+    const size_t block_request_;
+};
+
+} // namespace node
+} // namespace libbitcoin
+
+#endif
+

--- a/include/bitcoin/node/reservations.hpp
+++ b/include/bitcoin/node/reservations.hpp
@@ -32,7 +32,7 @@
 namespace libbitcoin {
 namespace node {
 
-// Thread safe.
+// Class to manage a set of reservation objects during sync, thread safe.
 class BCN_API reservations
 {
 public:
@@ -42,6 +42,7 @@ public:
         float arithmentic_mean;
         float standard_deviation;
     } rate_summary;
+
     typedef std::shared_ptr<reservations> ptr;
 
     /// Construct a reservation table of reservations, allocating hashes evenly
@@ -84,10 +85,6 @@ private:
     // Protected by mutex.
     reservation::list table_;
     mutable upgrade_mutex mutex_;
-
-    // Settings.
-    const float factor_;
-    const size_t block_request_;
 };
 
 } // namespace node

--- a/include/bitcoin/node/session_block_sync.hpp
+++ b/include/bitcoin/node/session_block_sync.hpp
@@ -33,6 +33,7 @@
 namespace libbitcoin {
 namespace node {
 
+/// Class to manage initial block download connections, thread safe.
 class BCN_API session_block_sync
   : public network::session_batch, track<session_block_sync>
 {

--- a/include/bitcoin/node/session_block_sync.hpp
+++ b/include/bitcoin/node/session_block_sync.hpp
@@ -26,6 +26,8 @@
 #include <bitcoin/blockchain.hpp>
 #include <bitcoin/network.hpp>
 #include <bitcoin/node/define.hpp>
+#include <bitcoin/node/hash_queue.hpp>
+#include <bitcoin/node/reservations.hpp>
 #include <bitcoin/node/settings.hpp>
 
 namespace libbitcoin {
@@ -37,31 +39,30 @@ class BCN_API session_block_sync
 public:
     typedef std::shared_ptr<session_block_sync> ptr;
 
-    session_block_sync(network::p2p& network, const hash_list& hashes,
-        size_t first_height, const settings& settings,
-        blockchain::block_chain& chain);
+    session_block_sync(network::p2p& network, hash_queue& hashes,
+        blockchain::block_chain& chain, const settings& settings);
 
     void start(result_handler handler);
 
 private:
     void handle_started(const code& ec, result_handler handler);
-    void new_connection(size_t start_height, size_t partition,
-        network::connector::ptr connect, result_handler handler);
+    void new_connection(network::connector::ptr connect,
+        reservation::ptr row, result_handler handler);
+    void handle_complete(const code& ec, network::connector::ptr connect,
+        reservation::ptr row, result_handler handler);
     void handle_connect(const code& ec, network::channel::ptr channel,
-        size_t start_height, size_t partition, network::connector::ptr connect,
+        network::connector::ptr connect, reservation::ptr row,
         result_handler handler);
-    void handle_complete(const code& ec, size_t start_height, size_t partition,
-        network::connector::ptr connect, result_handler handler);
-    void handle_channel_start(const code& ec, size_t start_height,
-        size_t partition, network::connector::ptr connect,
-        network::channel::ptr channel, result_handler handler);
-    void handle_channel_stop(const code& ec, size_t partition);
+    void handle_channel_start(const code& ec, network::channel::ptr channel,
+        network::connector::ptr connect, reservation::ptr row,
+        result_handler handler);
+    void handle_channel_stop(const code& ec, reservation::ptr row);
 
-    const size_t offset_;
-    const size_t first_height_;
-    const hash_list& hashes_;
-    const settings& settings_;
+    // These are thread safe.
     blockchain::block_chain& blockchain_;
+    reservations reservations_;
+
+    const settings& settings_;
 };
 
 } // namespace node

--- a/include/bitcoin/node/session_header_sync.hpp
+++ b/include/bitcoin/node/session_header_sync.hpp
@@ -31,7 +31,8 @@
 
 namespace libbitcoin {
 namespace node {
-
+    
+/// Class to manage initial header download connection, thread safe.
 class BCN_API session_header_sync
   : public network::session_batch, track<session_header_sync>
 {
@@ -55,7 +56,6 @@ private:
         network::connector::ptr connect, result_handler handler);
     void handle_complete(const code& ec, network::connector::ptr connect,
         result_handler handler);
-
     void handle_channel_start(const code& ec, network::connector::ptr connect,
         network::channel::ptr channel, result_handler handler);
     void handle_channel_stop(const code& ec);

--- a/install.sh
+++ b/install.sh
@@ -691,7 +691,7 @@ build_from_travis()
 #==============================================================================
 build_all()
 {
-    build_from_tarball_boost $BOOST_URL    $BOOST_ARCHIVE    bzip2 .      $PARALLEL  "$BUILD_BOOST"    "${BOOST_OPTIONS[@]}"
+    build_from_tarball_boost $BOOST_URL $BOOST_ARCHIVE bzip2 . $PARALLEL "$BUILD_BOOST" "${BOOST_OPTIONS[@]}"
     build_from_github libbitcoin secp256k1 version4 $PARALLEL ${SECP256K1_OPTIONS[@]} "$@"
     build_from_github libbitcoin libbitcoin master $PARALLEL ${BITCOIN_OPTIONS[@]} "$@"
     build_from_github libbitcoin libbitcoin-consensus version2 $PARALLEL ${BITCOIN_CONSENSUS_OPTIONS[@]} "$@"

--- a/src/hash_queue.cpp
+++ b/src/hash_queue.cpp
@@ -1,0 +1,345 @@
+/**
+ * Copyright (c) 2011-2016 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/node/hash_queue.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <iterator>
+#include <bitcoin/blockchain.hpp>
+
+namespace libbitcoin {
+namespace node {
+
+using namespace bc::blockchain;
+using namespace bc::chain;
+using namespace bc::config;
+using namespace bc::message;
+
+hash_queue::hash_queue(const config::checkpoint::list& checkpoints)
+  : height_(0),
+    head_(list_.begin()),
+    checkpoints_(checkpoints)
+{
+}
+
+bool hash_queue::empty() const
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock(mutex_);
+
+    return is_empty();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+size_t hash_queue::size() const
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock(mutex_);
+
+    return get_size();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+size_t hash_queue::first_height() const
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock(mutex_);
+
+    return height_;
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+size_t hash_queue::last_height() const
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock(mutex_);
+
+    return last();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+hash_digest hash_queue::last_hash() const
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock(mutex_);
+
+    return is_empty() ? null_hash : list_.back();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+void hash_queue::shrink()
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    unique_lock(mutex_);
+
+    list_.erase(list_.begin(), head_);
+    head_ = list_.begin();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+void hash_queue::initialize(const hash_digest& hash, size_t height)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    mutex_.lock_upgrade();
+
+    const auto size = 
+        (checkpoints_.empty() || height > checkpoints_.back().height()) ? 1 :
+        (checkpoints_.back().height() - height + 1);
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    mutex_.unlock_upgrade_and_lock();
+
+    list_.clear();
+    list_.reserve(size);
+    list_.emplace_back(hash);
+    head_ = list_.begin();
+    height_ = height;
+
+    mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+bool hash_queue::pop(size_t count)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    mutex_.lock_upgrade();
+
+    if (count == 0)
+    {
+        mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return true;
+    }
+
+    if (is_empty())
+    {
+        mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return false;
+    }
+
+    const auto size = get_size();
+
+    if (count > size)
+    {
+        //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        mutex_.unlock_upgrade_and_lock();
+
+        BITCOIN_ASSERT(size <= max_size_t - height_);
+        height_ += size;
+
+        list_.clear();
+        head_ = list_.begin();
+
+        mutex_.unlock();
+        //---------------------------------------------------------------------
+        return false;
+    }
+    
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    mutex_.unlock_upgrade_and_lock();
+
+    BITCOIN_ASSERT(count <= max_size_t - height_);
+    height_ += count;
+
+    list_.erase(list_.begin(), head_ + count);
+    head_ = list_.begin();
+
+    mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    return true;
+}
+
+bool hash_queue::pop(hash_digest& out_hash, size_t& out_height)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    mutex_.lock_upgrade();
+
+    if (is_empty())
+    {
+        mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return false;
+    }
+
+    out_height = height_;
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    mutex_.unlock_upgrade_and_lock();
+
+    std::swap(out_hash, *head_);
+    ++head_;
+    ++height_;
+
+    mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    return true;
+}
+
+void hash_queue::push(const hash_digest& hash)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    mutex_.lock_upgrade();
+
+    // Iterators may are invalidated when capacity is increased.
+    const auto capacity = list_.size() == list_.capacity();
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    mutex_.unlock_upgrade_and_lock();
+
+    if (capacity)
+    {
+        list_.erase(list_.begin(), head_);
+        head_ = list_.begin();
+    }
+
+    list_.emplace_back(hash);
+
+    if (capacity || list_.size() == 1)
+        head_ = list_.begin();
+
+    mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+bool hash_queue::push(headers::ptr message)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    mutex_.lock_upgrade();
+
+    // Cannot merge into an empty chain.
+    if (is_empty())
+    {
+        mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return false;
+    }
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    mutex_.unlock_upgrade_and_lock();
+
+    const auto result = merge(message);
+
+    mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    return result;
+}
+
+// private
+//-----------------------------------------------------------------------------
+
+// TODO: add PoW validation to reduce importance of intermediate checkpoints.
+bool hash_queue::merge(headers::ptr message)
+{
+    // In case emplacement exceeds capacity and invalidate the header pointer.
+    list_.erase(list_.begin(), head_);
+
+    for (const auto& header: message->elements)
+    {
+        const auto& new_hash = header.hash();
+        const auto next_height = last_height() + 1;
+        const auto& last_hash = is_empty() ? null_hash : list_.back();
+
+        if (!linked(header, last_hash) || !check(new_hash, next_height))
+        {
+            rollback();
+            head_ = list_.begin();
+            return false;
+        }
+
+        list_.emplace_back(new_hash);
+    }
+
+    head_ = list_.begin();
+    return true;
+}
+
+void hash_queue::rollback()
+{
+    if (!checkpoints_.empty())
+    {
+        for (auto it = checkpoints_.rbegin(); it != checkpoints_.rend(); ++it)
+        {
+            auto match = std::find(head_, list_.end(), it->hash());
+
+            if (match != list_.end())
+            {
+                list_.erase(++match, list_.end());
+                return;
+            }
+        }
+    }
+
+    // This assumes that if there are no checkpoints that currently match we
+    // trust only the first logical element in the list. This may not be
+    // the case depending on how the list has been initialized and/or used.
+    if (!is_empty())
+    {
+        list_.erase(head_ + 1, list_.end());
+        list_.erase(list_.begin(), head_);
+    }
+
+    head_ = list_.begin();
+}
+
+bool hash_queue::check(const hash_digest& hash, size_t height) const
+{
+    return checkpoint::validate(hash, height, checkpoints_);
+}
+
+bool hash_queue::linked(const chain::header& header,
+    const hash_digest& hash) const
+{
+    return header.previous_block_hash == hash;
+}
+
+bool hash_queue::is_empty() const
+{
+    return get_size() == 0;
+}
+
+size_t hash_queue::get_size() const
+{
+    hash_list::const_iterator it = head_;
+    const auto value = std::distance(it, list_.end());
+    return value;
+}
+
+size_t hash_queue::last() const
+{
+    return is_empty() ? height_ : height_ + get_size() - 1;
+}
+
+} // namespace node
+} // namespace libbitcoin

--- a/src/p2p_node.cpp
+++ b/src/p2p_node.cpp
@@ -82,13 +82,14 @@ void p2p_node::handle_blockchain_start(const code& ec, result_handler handler)
 {
     if (ec)
     {
-        log::info(LOG_NODE)
+        log::error(LOG_NODE)
             << "Blockchain failed to start: " << ec.message();
         handler(ec);
         return;
     }
 
     size_t height;
+
     if (!blockchain_.get_last_height(height))
     {
         log::error(LOG_NODE)

--- a/src/p2p_node.cpp
+++ b/src/p2p_node.cpp
@@ -38,8 +38,9 @@ using std::placeholders::_2;
 
 p2p_node::p2p_node(const configuration& configuration)
   : p2p(configuration.network),
-    settings_(configuration.node),
-    blockchain_(configuration.chain, configuration.database)
+    hashes_(configuration.chain.checkpoints),
+    blockchain_(configuration.chain, configuration.database),
+    settings_(configuration.node)
 {
 }
 
@@ -139,19 +140,23 @@ void p2p_node::handle_fetch_header(const code& ec, const header& block_header,
         return;
     }
 
+    log::info(LOG_NODE)
+        << "Blockchain start height is (" << block_height << ").";
+
+    // Add the seed entry, the top trusted block hash.
+    hashes_.initialize(block_header.hash(), block_height);
     const auto chain_settings = blockchain_.chain_settings();
-    const config::checkpoint top(block_header.hash(), block_height);
 
     const auto start_handler =
         std::bind(&p2p_node::handle_headers_synchronized,
-            shared_from_base<p2p_node>(), _1, top.height(), handler);
+            shared_from_base<p2p_node>(), _1, handler);
 
     // The instance is retained by the stop handler (i.e. until shutdown).
-    attach<session_header_sync>(hashes_, top, settings_, chain_settings)->
+    attach<session_header_sync>(hashes_, settings_, chain_settings)->
         start(start_handler);
 }
 
-void p2p_node::handle_headers_synchronized(const code& ec, size_t block_height,
+void p2p_node::handle_headers_synchronized(const code& ec,
     result_handler handler)
 {
     if (stopped())
@@ -168,24 +173,25 @@ void p2p_node::handle_headers_synchronized(const code& ec, size_t block_height,
         return;
     }
 
-    // First height in hew headers.
-    const auto first_height = block_height + 1;
-    const auto end_height = first_height + hashes_.size() - 1;
-
-    log::info(LOG_NODE)
-        << "Starting block synchronization [" << first_height << "-"
-        << end_height << "]";
+    // Remove the seed entry so we don't try to sync it.
+    if (!hashes_.pop())
+    {
+        log::error(LOG_NODE)
+            << "Failure synchronizing headers, no seed entry.";
+        handler(error::operation_failed);
+        return;
+    }
 
     const auto start_handler =
         std::bind(&p2p_node::handle_blocks_synchronized,
-            shared_from_base<p2p_node>(), _1, first_height, handler);
+            shared_from_base<p2p_node>(), _1, handler);
 
     // The instance is retained by the stop handler (i.e. until shutdown).
-    attach<session_block_sync>(hashes_, first_height, settings_, blockchain_)->
+    attach<session_block_sync>(hashes_, blockchain_, settings_)->
         start(start_handler);
 }
 
-void p2p_node::handle_blocks_synchronized(const code& ec, size_t start_height,
+void p2p_node::handle_blocks_synchronized(const code& ec,
     result_handler handler)
 {
     if (stopped())
@@ -202,9 +208,7 @@ void p2p_node::handle_blocks_synchronized(const code& ec, size_t start_height,
         return;
     }
 
-    log::info(LOG_NODE)
-        << "Completed block synchronization [" << start_height
-        << "-" << height() << "]";
+    // TODO: validate chain is complete.
 
     // This is the end of the derived run sequence.
     p2p::run(handler);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -136,9 +136,9 @@ options_metadata parser::load_settings()
         "The port for incoming connections, defaults to 8333."
     )
     (
-        "network.connection_limit",
-        value<uint32_t>(&configured.network.connection_limit),
-        "The target number of total network connections, defaults to 16."
+        "network.inbound_connections",
+        value<uint32_t>(&configured.network.inbound_connections),
+        "The target number of incoming network connections, defaults to 8."
     )
     (
         "network.outbound_connections",
@@ -164,11 +164,6 @@ options_metadata parser::load_settings()
         "network.channel_handshake_seconds",
         value<uint32_t>(&configured.network.channel_handshake_seconds),
         "The time limit to complete the connection handshake, defaults to 30."
-    )
-    (
-        "network.channel_poll_seconds",
-        value<uint32_t>(&configured.network.channel_poll_seconds),
-        "The polling interval for initial block download, defaults to 1."
     )
     (
         "network.channel_heartbeat_minutes",
@@ -284,14 +279,9 @@ options_metadata parser::load_settings()
 
     /* [node] */
     (
-        "node.block_bytes_per_second",
-        value<uint32_t>(&configured.node.block_bytes_per_second),
-        "The minimum block byte rate required from a peer during block sync, defaults to 100000."
-    )
-    (
-        "node.headers_per_second",
-        value<uint32_t>(&configured.node.headers_per_second),
-        "The minimum header rate required from a peer during header sync, defaults to 10000."
+        "node.download_connections",
+        value<uint32_t>(&configured.node.download_connections),
+        "The maximum number of connections for initial block download, defaults to 8."
     )
     (
         "node.peer",

--- a/src/protocol_block_sync.cpp
+++ b/src/protocol_block_sync.cpp
@@ -74,7 +74,7 @@ void protocol_block_sync::send_get_blocks(event_handler complete, bool reset)
     // If the channel has been drained of hashes we are done.
     if (reservation_->empty())
     {
-        log::info(LOG_PROTOCOL)
+        log::debug(LOG_PROTOCOL)
             << "Stopping complete slot (" << reservation_->slot() << ").";
         complete(error::success);
         return;
@@ -132,7 +132,7 @@ bool protocol_block_sync::handle_receive(const code& ec, block::ptr message,
 
     if (reservation_->partitioned())
     {
-        log::info(LOG_PROTOCOL)
+        log::debug(LOG_PROTOCOL)
             << "Restarting partitioned slot (" << reservation_->slot() << ").";
         complete(error::channel_stopped);
         return false;
@@ -154,7 +154,7 @@ void protocol_block_sync::handle_event(const code& ec, event_handler complete)
 
     if (ec && ec != error::channel_timeout)
     {
-        log::info(LOG_PROTOCOL)
+        log::debug(LOG_PROTOCOL)
             << "Failure in block sync timer for slot (" << reservation_->slot()
             << ") " << ec.message();
         complete(ec);
@@ -163,7 +163,7 @@ void protocol_block_sync::handle_event(const code& ec, event_handler complete)
 
     if (reservation_->expired())
     {
-        log::info(LOG_PROTOCOL)
+        log::debug(LOG_PROTOCOL)
             << "Restarting slow slot (" << reservation_->slot() << ")";
         complete(error::channel_timeout);
         return;

--- a/src/protocol_header_sync.cpp
+++ b/src/protocol_header_sync.cpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <functional>
 #include <bitcoin/network.hpp>
+#include <bitcoin/node/hash_queue.hpp>
 #include <bitcoin/node/p2p_node.hpp>
 
 namespace libbitcoin {
@@ -38,118 +39,48 @@ using namespace bc::network;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
-// We measure the header rate in a moving 5 second window.
-static constexpr size_t header_period_seconds = 5;
+// The protocol maximum size for get data header requests.
+static constexpr size_t max_header_response = 2000;
 
-static constexpr size_t full_headers = 2000;
-static const asio::seconds header_period(header_period_seconds);
+// The interval in which header download rate is measured and tested.
+static const asio::seconds expiry_interval(5);
 
 protocol_header_sync::protocol_header_sync(p2p& network,
-    channel::ptr channel, uint32_t minimum_rate, size_t first_height,
-    hash_list& hashes, const checkpoint::list& checkpoints)
+    channel::ptr channel, hash_queue& hashes, uint32_t minimum_rate,
+    const checkpoint::list& checkpoints)
   : protocol_timer(network, channel, true, NAME),
     hashes_(hashes),
     current_second_(0),
     minimum_rate_(minimum_rate),
     start_size_(hashes.size()),
-    first_height_(first_height),
-    last_height_(last_height(first_height, hashes, checkpoints)),
+    final_height_(final_height(hashes, checkpoints)),
     checkpoints_(checkpoints),
     CONSTRUCT_TRACK(protocol_header_sync)
 {
-    // TODO: convert to exception (public API).
-    BITCOIN_ASSERT_MSG(!hashes_.empty(), "The starting header must be set.");
 }
 
 // Utilities
 // ----------------------------------------------------------------------------
 
-size_t protocol_header_sync::last_height(size_t first_height,
-    hash_list& headers, const checkpoint::list& checkpoints)
+// We assume here that hashes in the initial list are ordered and trusted.
+// Typically the initial list would contain one hash from the chain top.
+size_t protocol_header_sync::final_height(hash_queue& hashes,
+    const checkpoint::list& checkpoints)
 {
-    const auto current_block = first_height + headers.size() - 1;
-    return checkpoints.empty() ? current_block :
-        std::max(checkpoints.back().height(), current_block);
+    const auto last_height = hashes.last_height();
+    return checkpoints.empty() ? last_height :
+        std::max(checkpoints.back().height(), last_height);
 }
 
-size_t protocol_header_sync::current_height() const
+size_t protocol_header_sync::next_height() const
 {
-    return hashes_.size() + first_height_;
+    return hashes_.last_height() + 1;
 }
 
-size_t protocol_header_sync::current_rate() const
+size_t protocol_header_sync::sync_rate() const
 {
+    // We can never roll back prior to start size since it's min final height.
     return (hashes_.size() - start_size_) / current_second_;
-}
-
-bool protocol_header_sync::linked(const header& header,
-    const hash_digest& hash) const
-{
-    return header.previous_block_hash == hash;
-}
-
-bool protocol_header_sync::checks(const hash_digest& hash, size_t height) const
-{
-    return checkpoint::validate(hash, height, checkpoints_);
-}
-
-bool protocol_header_sync::proof_of_work(const header& header,
-    size_t height) const
-{
-    if (height <= last_height_)
-        return true;
-
-    // TODO: determine if the PoW for this block is valid.
-    // This allows us to collect headers beyond the last checkpoint.
-    // We can attempt to fill these blocks and the the sync will terminate at
-    // the last validated block (i.e. above the last checkpoint).
-    return true;
-}
-
-// TODO: ensure that this is correct (using valid block sync).
-void protocol_header_sync::rollback()
-{
-    if (!checkpoints_.empty())
-    {
-        for (auto it = checkpoints_.rbegin(); it != checkpoints_.rend(); ++it)
-        {
-            auto match = std::find(hashes_.begin(), hashes_.end(), it->hash());
-            if (match != hashes_.end())
-            {
-                hashes_.erase(++match, hashes_.end());
-                return;
-            }
-        }
-    }
-
-    hashes_.resize(1);
-}
-
-// It's not necessary to roll back for invalid PoW. We just stop and move to
-// another peer. As long as we are getting valid PoW there is no way to know
-// we aren't of on a fork, so moving on is sufficient (and generally faster).
-bool protocol_header_sync::merge_headers(headers::ptr message)
-{
-    auto previous = hashes_.back();
-
-    for (const auto& header: message->elements)
-    {
-        const auto current = header.hash();
-
-        if (!linked(header, previous) || !checks(current, current_height()))
-        {
-            rollback();
-            return false;
-        }
-
-        if (!proof_of_work(header, current_height()))
-            return false;
-
-        previous = current;
-        hashes_.push_back(current);
-    }
-
-    return true;
 }
 
 // Start sequence.
@@ -157,21 +88,8 @@ bool protocol_header_sync::merge_headers(headers::ptr message)
 
 void protocol_header_sync::start(event_handler handler)
 {
-    const auto peer_top = peer_version().start_height;
-
-    if (peer_top < last_height_)
-    {
-        log::info(LOG_PROTOCOL)
-            << "Start height (" << peer_top << ") below header sync target ("
-            << last_height_ << ") from [" << authority() << "]";
-
-        // This is a successful vote.
-        headers_complete(error::success, handler);
-        return;
-    }
-
     auto complete = synchronize(BIND2(headers_complete, _1, handler), 1, NAME);
-    protocol_timer::start(header_period, BIND2(handle_event, _1, complete));
+    protocol_timer::start(expiry_interval, BIND2(handle_event, _1, complete));
 
     SUBSCRIBE3(headers, handle_receive, _1, _2, complete);
 
@@ -187,10 +105,11 @@ void protocol_header_sync::send_get_headers(event_handler complete)
     if (stopped())
         return;
 
-    BITCOIN_ASSERT_MSG(!hashes_.empty(), "The start header must be set.");
-
-    const auto stop_hash = checkpoints_.back().hash();
-    const get_headers packet{ { hashes_.back() }, stop_hash };
+    const get_headers packet
+    {
+        { hashes_.last_hash() },
+        checkpoints_.back().hash()
+    };
 
     SEND2(packet, handle_send, _1, complete);
 }
@@ -224,7 +143,8 @@ bool protocol_header_sync::handle_receive(const code& ec, headers::ptr message,
         return false;
     }
 
-    if (!merge_headers(message))
+    // A merge failure includes automatic rollback to last trust point.
+    if (!hashes_.push(message))
     {
         log::warning(LOG_PROTOCOL)
             << "Failure merging headers from [" << authority() << "]";
@@ -232,20 +152,22 @@ bool protocol_header_sync::handle_receive(const code& ec, headers::ptr message,
         return false;
     }
 
+    const auto next = next_height();
+
     log::info(LOG_PROTOCOL)
-        << "Synced headers " << current_height() - message->elements.size()
-        << "-" << current_height() - 1 << " from [" << authority() << "]";
+        << "Synced headers " << next - message->elements.size()
+        << "-" << (next - 1) << " from [" << authority() << "]";
 
 
     // If we reached the last height the sync is complete/success.
-    if (current_height() > last_height_)
+    if (next > final_height_)
     {
         complete(error::success);
         return false;
     }
 
     // If we received fewer than 2000 the peer is exhausted, try another.
-    if (message->elements.size() < full_headers)
+    if (message->elements.size() < max_header_response)
     {
         complete(error::operation_failed);
         return false;
@@ -275,14 +197,14 @@ void protocol_header_sync::handle_event(const code& ec, event_handler complete)
     }
 
     // It was a timeout, so ten more seconds have passed.
-    current_second_ += header_period_seconds;
+    current_second_ += expiry_interval.total_seconds();
 
     // Drop the channel if it falls below the min sync rate averaged over all.
-    if (current_rate() < minimum_rate_)
+    if (sync_rate() < minimum_rate_)
     {
         log::info(LOG_PROTOCOL)
-            << "Header sync rate (" << current_rate()
-            << "/sec) from [" << authority() << "]";
+            << "Header sync rate (" << sync_rate() << "/sec) from ["
+            << authority() << "]";
         complete(error::channel_timeout);
         return;
     }

--- a/src/protocol_header_sync.cpp
+++ b/src/protocol_header_sync.cpp
@@ -202,7 +202,7 @@ void protocol_header_sync::handle_event(const code& ec, event_handler complete)
     // Drop the channel if it falls below the min sync rate averaged over all.
     if (sync_rate() < minimum_rate_)
     {
-        log::info(LOG_PROTOCOL)
+        log::debug(LOG_PROTOCOL)
             << "Header sync rate (" << sync_rate() << "/sec) from ["
             << authority() << "]";
         complete(error::channel_timeout);

--- a/src/reservation.cpp
+++ b/src/reservation.cpp
@@ -95,17 +95,17 @@ bool reservation::expired() const
     const auto below_average = deviation < 0;
     const auto expired = below_average && outlier;
 
-    log::debug(LOG_PROTOCOL)
-        << "Statistics for slot (" << slot() << ")"
-        << " spd:" << (rate * duration_to_seconds)
-        << " adj:" << (adjusted_rate * duration_to_seconds)
-        << " avg:" << (statistics.arithmentic_mean * duration_to_seconds)
-        << " dev:" << (deviation * duration_to_seconds)
-        << " sdv:" << (statistics.standard_deviation * duration_to_seconds)
-        << " cnt:" << (statistics.active_count)
-        << " neg:" << (below_average ? "T" : "F")
-        << " out:" << (outlier ? "T" : "F")
-        << " exp:" << (expired ? "T" : "F");
+    ////log::debug(LOG_PROTOCOL)
+    ////    << "Statistics for slot (" << slot() << ")"
+    ////    << " spd:" << (rate * duration_to_seconds)
+    ////    << " adj:" << (adjusted_rate * duration_to_seconds)
+    ////    << " avg:" << (statistics.arithmentic_mean * duration_to_seconds)
+    ////    << " dev:" << (deviation * duration_to_seconds)
+    ////    << " sdv:" << (statistics.standard_deviation * duration_to_seconds)
+    ////    << " cnt:" << (statistics.active_count)
+    ////    << " neg:" << (below_average ? "T" : "F")
+    ////    << " out:" << (outlier ? "T" : "F")
+    ////    << " exp:" << (expired ? "T" : "F");
 
     return expired;
 }
@@ -179,9 +179,6 @@ void reservation::update_rate_history(size_t size,
     rate_.store(rate);
     adjusted_rate_.store(adjusted_rate);
 
-    ////const auto percent = discount.count() > 0 ?
-    ////    1.0f * cost.count() / discount.count() : 0.0f;
-    ////
     ////log::debug(LOG_PROTOCOL)
     ////    << "Records (" << slot() << ") "
     ////    << " size: " << size
@@ -190,7 +187,6 @@ void reservation::update_rate_history(size_t size,
     ////    << " totl: " << total
     ////    << " time: " << period_count
     ////    << " disc: " << import_count
-    ////    << " perc: " << percent
     ////    << " full: " << (full ? "true" : "false");
 }
 
@@ -299,7 +295,7 @@ void reservation::import(block::ptr block)
 
     if (success)
     {
-        const auto formatter = 
+        static const auto formatter = 
             "Imported block #%06i (%02i) [%s] %07.3f %-01.2f%%";
 
         const auto slower_rate = rate_.load();

--- a/src/reservation.cpp
+++ b/src/reservation.cpp
@@ -1,0 +1,434 @@
+/**
+ * Copyright (c) 2011-2016 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/node/reservation.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <utility>
+#include <boost/format.hpp>
+#include <bitcoin/bitcoin.hpp>
+#include <bitcoin/node/reservations.hpp>
+
+namespace libbitcoin {
+namespace node {
+
+using namespace std::chrono;
+using namespace bc::chain;
+
+// The window for the rate moving average.
+static const seconds rate_window(10);
+
+// Log the rate block of block download in seconds.
+static constexpr size_t duration_to_seconds = 10 * 1000 * 1000;
+
+reservation::reservation(reservations& reservations, size_t slot,
+    float rate_factor)
+  : slot_(slot),
+    factor_(rate_factor),
+    idle_(true),
+    rate_(0),
+    adjusted_rate_(0),
+    pending_(true),
+    partitioned_(false),
+    reservations_(reservations)
+{
+}
+
+size_t reservation::slot() const
+{
+    return slot_;
+}
+
+system_clock::time_point reservation::current_time() const
+{
+    return system_clock::now();
+}
+
+// Rate methods.
+//-----------------------------------------------------------------------------
+
+void reservation::set_idle()
+{
+    rate_.store(0);
+    adjusted_rate_.store(0);
+    idle_.store(true);
+}
+
+bool reservation::idle() const
+{
+    return idle_.load();
+}
+
+float reservation::rate() const
+{
+    return adjusted_rate_.load();
+}
+
+// Ignore idleness here, called only from an active channel, avoiding a race.
+bool reservation::expired() const
+{
+    const auto rate = rate_.load();
+    const auto adjusted_rate = adjusted_rate_.load();
+    const auto statistics = reservations_.rates();
+    const auto deviation = adjusted_rate - statistics.arithmentic_mean;
+    const auto acceptable_deviation = factor_ * statistics.standard_deviation;
+    const auto outlier = abs(deviation) > acceptable_deviation;
+    const auto below_average = deviation < 0;
+    const auto expired = below_average && outlier;
+
+    log::debug(LOG_PROTOCOL)
+        << "Statistics for slot (" << slot() << ")"
+        << " spd:" << (rate * duration_to_seconds)
+        << " adj:" << (adjusted_rate * duration_to_seconds)
+        << " avg:" << (statistics.arithmentic_mean * duration_to_seconds)
+        << " dev:" << (deviation * duration_to_seconds)
+        << " sdv:" << (statistics.standard_deviation * duration_to_seconds)
+        << " cnt:" << (statistics.active_count)
+        << " neg:" << (below_average ? "T" : "F")
+        << " out:" << (outlier ? "T" : "F")
+        << " exp:" << (expired ? "T" : "F");
+
+    return expired;
+}
+
+void reservation::clear_rate_history()
+{
+    rate_.store(0);
+    adjusted_rate_.store(0);
+
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    unique_lock lock(history_mutex_);
+
+    history_.clear();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+// Duration counts are normalized once cast to system_clock::duration.
+void reservation::update_rate_history(size_t size,
+    const system_clock::duration& cost)
+{
+    const auto now = current_time();
+    const auto limit = now - rate_window;
+    system_clock::duration import(0);
+    float total = 0;
+
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    history_mutex_.lock();
+
+    const auto records = history_.size();
+
+    // Remove expired entries from the head of the queue.
+    for (auto it = history_.begin(); it != history_.end() && it->time < limit;
+        it = history_.erase(it));
+
+    const auto full = records > history_.size();
+
+    // Add the new entry to the tail of the queue.
+    history_.push_back({ size, cost, now });
+
+    //------------------------------------------------------------------------
+    history_mutex_.unlock_and_lock_shared();
+
+    // Calculate the rate summary.
+    for (const auto& record: history_)
+    {
+        // TODO: guard against overflows.
+        total += record.size;
+        import += record.import;
+    }
+
+    // If we have deleted any entries then use the full period.
+    const auto period = full ? rate_window : now - history_.front().time;
+
+    history_mutex_.unlock_shared();
+    ///////////////////////////////////////////////////////////////////////////
+
+    const auto import_count = import.count();
+    const auto period_count = period.count();
+
+    auto rate = total / period_count;
+    auto adjusted_rate = total / (period_count - import_count);
+
+    if (rate != rate)
+        rate = 0;
+
+    if (adjusted_rate != adjusted_rate)
+        adjusted_rate = 0;
+
+    rate_.store(rate);
+    adjusted_rate_.store(adjusted_rate);
+
+    ////const auto percent = discount.count() > 0 ?
+    ////    1.0f * cost.count() / discount.count() : 0.0f;
+    ////
+    ////log::debug(LOG_PROTOCOL)
+    ////    << "Records (" << slot() << ") "
+    ////    << " size: " << size
+    ////    << " cost: " << cost.count()
+    ////    << " recs: " << records
+    ////    << " totl: " << total
+    ////    << " time: " << period_count
+    ////    << " disc: " << import_count
+    ////    << " perc: " << percent
+    ////    << " full: " << (full ? "true" : "false");
+}
+
+// Hash methods.
+//-----------------------------------------------------------------------------
+
+bool reservation::empty() const
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock lock(hash_mutex_);
+
+    return heights_.empty();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+size_t reservation::size() const
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock lock(hash_mutex_);
+
+    return heights_.size();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+// Obtain and clear the outstanding blocks request.
+message::get_data reservation::request(bool reset)
+{
+    message::get_data packet;
+
+    if (reset)
+        clear_rate_history();
+
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    hash_mutex_.lock_upgrade();
+
+    if (!reset && !pending_)
+    {
+        hash_mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return packet;
+    }
+
+    auto height = heights_.right.begin();
+    const auto end = heights_.right.end();
+    const auto id = message::inventory_type_id::block;
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    hash_mutex_.unlock_upgrade_and_lock();
+
+    // Build get_blocks request message.
+    for (; height != end; ++height)
+    {
+        const message::inventory_vector inventory{ id, height->second };
+        packet.inventories.emplace_back(inventory);
+    }
+
+    pending_ = false;
+    hash_mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    return packet;
+}
+
+void reservation::insert(const hash_digest& hash, size_t height)
+{
+    BITCOIN_ASSERT(height <= max_uint32);
+    const auto height32 = static_cast<uint32_t>(height);
+
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    unique_lock lock(hash_mutex_);
+
+    pending_ = true;
+    heights_.insert({ hash, height32 });
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+void reservation::import(block::ptr block)
+{
+    uint32_t height;
+    const auto hash = block->header.hash();
+    const auto encoded = encode_hash(hash);
+
+    // This prevents inclusion of a reservation rate before the first block.
+    // Expiration does not consider idelness so delay does not prevent closure.
+    idle_.store(false);
+
+    if (!find_height_and_erase(hash, height))
+    {
+        log::debug(LOG_PROTOCOL)
+            << "Ignoring unsolicited block (" << slot() << ") ["
+            << encoded << "]";
+        return;
+    }
+
+    bool success;
+    const auto importer = [this, &block, &height, &success]()
+    {
+        success = reservations_.import(block, height);
+    };
+
+    const auto cost = timer<microseconds>::duration(importer);
+
+    if (success)
+    {
+        const auto formatter = 
+            "Imported block #%06i (%02i) [%s] %07.3f %-01.2f%%";
+
+        const auto slower_rate = rate_.load();
+        const auto faster_rate = adjusted_rate_.load();
+
+        // Convert rates to time per block based on common block count.
+        const auto lesser_time = 1 / faster_rate;
+        const auto greater_time = 1 / slower_rate;
+
+        // Calculate the percentage of total time spent in the database.
+        const auto factor = (greater_time - lesser_time) / greater_time;
+        const auto percent = factor != factor ? 0.0f : 100 * factor;
+
+        // Convert the total time to seconds.
+        auto rate = slower_rate * duration_to_seconds;
+        rate = rate != rate ? 0.0f : rate;
+
+        log::info(LOG_PROTOCOL)
+            << boost::format(formatter) % height % slot() % encoded % rate %
+            percent;
+
+        const auto size = /*block->header.transaction_count*/ 1u;
+        update_rate_history(size, cost);
+    }
+    else
+    {
+        log::debug(LOG_PROTOCOL)
+            << "Stopped before importing block (" << slot() << ") ["
+            << encoded << "]";
+    }
+
+    if (empty())
+        reservations_.populate(shared_from_this());
+}
+
+bool reservation::partitioned()
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    hash_mutex_.lock_upgrade();
+
+    if (partitioned_)
+    {
+        //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        hash_mutex_.unlock_upgrade_and_lock();
+        partitioned_ = false;
+        pending_ = true;
+        hash_mutex_.unlock();
+        //---------------------------------------------------------------------
+        return true;
+    }
+
+    hash_mutex_.unlock_upgrade();
+    ///////////////////////////////////////////////////////////////////////////
+
+    return false;
+}
+
+// Give the minimal row ~ half of our hashes.
+void reservation::partition(reservation::ptr minimal)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    hash_mutex_.lock_upgrade();
+
+    const auto own_size = heights_.size();
+
+    // Take half of the maximal reservation, rounding up to get last entry.
+    BITCOIN_ASSERT(own_size < max_size_t && (own_size + 1) / 2 <= max_uint32);
+    const auto offset = static_cast<uint32_t>(own_size + 1) / 2;
+
+    // Prevent a max block request overflow.
+    if (offset <= minimal->size())
+    {
+        hash_mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return;
+    }
+
+    auto it = heights_.right.begin();
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    hash_mutex_.unlock_upgrade_and_lock();
+
+    // TODO: move the range in a single command.
+    for (size_t index = 0; index < offset; ++index)
+    {
+        minimal->heights_.right.insert(std::move(*it));
+        it = heights_.right.erase(it);
+    }
+
+    minimal->pending_ = true;
+    partitioned_ = !heights_.empty();
+
+    hash_mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    log::debug(LOG_PROTOCOL)
+        << "Moved [" << minimal->size() << "] blocks from slot (" << slot()
+        << ") to slot (" << minimal->slot() << ") leaving [" << size() << "].";
+}
+
+bool reservation::find_height_and_erase(const hash_digest& hash,
+    uint32_t& out_height)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    hash_mutex_.lock_upgrade();
+
+    const auto it = heights_.left.find(hash);
+
+    if (it == heights_.left.end())
+    {
+        hash_mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return false;
+    }
+
+    out_height = it->second;
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    hash_mutex_.unlock_upgrade_and_lock();
+
+    heights_.left.erase(it);
+
+    hash_mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    return true;
+}
+
+} // namespace node
+} // namespace libbitcoin

--- a/src/reservations.cpp
+++ b/src/reservations.cpp
@@ -1,0 +1,278 @@
+/**
+ * Copyright (c) 2011-2016 libbitcoin developers (see AUTHORS)
+ *
+ * This file is part of libbitcoin.
+ *
+ * libbitcoin is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License with
+ * additional permissions to the one published by the Free Software
+ * Foundation, either version 3 of the License, or (at your option)
+ * any later version. For more information see LICENSE.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+#include <bitcoin/node/reservations.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <memory>
+#include <numeric>
+#include <utility>
+#include <vector>
+#include <bitcoin/bitcoin.hpp>
+#include <bitcoin/node/reservation.hpp>
+
+namespace libbitcoin {
+namespace node {
+
+using namespace bc::blockchain;
+using namespace bc::chain;
+
+// The allowed number of standard deviations below the norm.
+static constexpr float rate_factor = 1.0f;
+
+// The protocol maximum size of get data block requests.
+static constexpr size_t max_block_request = 50000;
+
+reservations::reservations(hash_queue& hashes, block_chain& chain,
+    const settings& settings)
+  : hashes_(hashes),
+    blockchain_(chain),
+    factor_(rate_factor),
+    block_request_(max_block_request)
+{
+    initialize(settings.download_connections);
+}
+
+bool reservations::import(block::ptr block, size_t height)
+{
+    // Thread safe.
+    return blockchain_.import(block, height);
+}
+
+// Rate methods.
+//-----------------------------------------------------------------------------
+
+// A statistical summary of block import rates.
+// This computation is not synchronized across rows because rates are cached.
+reservations::rate_summary reservations::rates() const
+{
+    // Copy row pointer table to prevent need for lock during iteration.
+    auto rows = table();
+    const auto idle = [](reservation::ptr row)
+    {
+        return row->idle();
+    };
+
+    // Remove idle rows.
+    rows.erase(std::remove_if(rows.begin(), rows.end(), idle), rows.end());
+    const auto row_count = rows.size();
+
+    // Guard against division by zero.
+    if (row_count == 0)
+        return{ row_count, 0, 0 };
+
+    // Optimize for trivial computation.
+    if (row_count == 1)
+        return{ row_count, rows.front()->rate(), 0 };
+
+    std::vector<float> rates(row_count);
+    const auto transformation = [](reservation::ptr row)
+    {
+        return row->rate();
+    };
+
+    // Convert to a rates table.
+    std::transform(rows.begin(), rows.end(), rates.begin(), transformation);
+    const float values = std::accumulate(rates.begin(), rates.end(), 0.0f);
+
+    // Calculate mean and sum of deviations.
+    const float arithmetic_mean = values / row_count;
+    const auto summary = [arithmetic_mean](float initial, float rate)
+    {
+        const auto difference = arithmetic_mean - rate;
+        return initial + (difference * difference);
+    };
+
+    // Calculate the stnadard deviation in the rate deviations.
+    float squares = std::accumulate(rates.begin(), rates.end(), 0.0f, summary);
+    float standard_deviation = sqrt(squares / row_count);
+    return{ row_count, arithmetic_mean, standard_deviation };
+}
+
+// Table methods.
+//-----------------------------------------------------------------------------
+
+reservation::list reservations::table() const
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    shared_lock lock(mutex_);
+
+    return table_;
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+void reservations::remove(reservation::ptr row)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    mutex_.lock_upgrade();
+
+    const auto it = std::find(table_.begin(), table_.end(), row);
+
+    if (it == table_.end())
+    {
+        mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return;
+    }
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    mutex_.unlock_upgrade_and_lock();
+
+    table_.erase(it);
+
+    mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+}
+
+// Hash methods.
+//-----------------------------------------------------------------------------
+
+void reservations::initialize(size_t size)
+{
+    // Guard against overflow by capping size.
+
+    const auto max_rows = max_size_t / block_request_;
+    auto rows = std::min(max_rows, size);
+
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    mutex_.lock_upgrade();
+
+    // The total number of blocks to sync.
+    const auto blocks = hashes_.size();
+
+    // Ensure that there is at least one block per row.
+    rows = std::min(rows, blocks);
+
+    if (rows == 0)
+    {
+        mutex_.unlock_upgrade();
+        //---------------------------------------------------------------------
+        return;
+    }
+
+    // Allocate no more than 50k headers per row.
+    const auto max_allocation = rows * block_request_;
+
+    // Allocate no more than 50k headers per row.
+    const auto allocation = std::min(blocks, max_allocation);
+
+    //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+    mutex_.unlock_upgrade_and_lock();
+
+    auto& self = *this;
+    table_.reserve(rows);
+
+    for (auto row = 0; row < rows; ++row)
+        table_.push_back(std::make_shared<reservation>(self, row, factor_));
+
+    size_t height;
+    hash_digest hash;
+
+    // The (allocation / rows) * rows cannot exceed allocation.
+    // The remainder is retained by the hash list for later reservation.
+    for (size_t base = 0; base < (allocation / rows); ++base)
+    {
+        for (size_t row = 0; row < rows; ++row)
+        {
+            hashes_.pop(hash, height);
+            table_[row]->insert(hash, height);
+        }
+    }
+
+    mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    log::debug(LOG_PROTOCOL)
+        << "Reserved " << allocation << " blocks to " << rows << " slots.";
+}
+
+void reservations::populate(reservation::ptr minimal)
+{
+    // Critical Section
+    ///////////////////////////////////////////////////////////////////////////
+    mutex_.lock();
+
+    const auto reserved = reserve(minimal);
+
+    if (!reserved)
+        partition(minimal);
+
+    mutex_.unlock();
+    ///////////////////////////////////////////////////////////////////////////
+
+    if (reserved)
+        log::debug(LOG_PROTOCOL)
+            << "Reserved " << minimal->size() << " blocks to slot ("
+            << minimal->slot() << ").";
+}
+
+// This can cause reduction of an active reservation.
+void reservations::partition(reservation::ptr minimal)
+{
+    // A false ptr indicates there are no partitionable rows.
+    const auto maximal = find_maximal();
+
+    // Do not select self as it would be pontless and produce deadlock.
+    if (maximal && maximal != minimal)
+        maximal->partition(minimal);
+}
+
+reservation::ptr reservations::find_maximal()
+{
+    if (table_.empty())
+        return nullptr;
+
+    // The maximal row is that with the most block hashes reserved.
+    const auto comparer = [](reservation::ptr left, reservation::ptr right)
+    {
+        return left->size() < right->size();
+    };
+
+    return *std::max_element(table_.begin(), table_.end(), comparer);
+}
+
+bool reservations::reserve(reservation::ptr minimal)
+{
+    // The unallocated blocks to sync.
+    const auto size = hashes_.size();
+
+    // Allocate no more than 50k headers to this row.
+    const auto existing = minimal->size();
+    const auto allocation = std::min(size, block_request_ - existing);
+
+    size_t height;
+    hash_digest hash;
+
+    for (size_t block = 0; block < allocation; ++block)
+    {
+        hashes_.pop(hash, height);
+        minimal->insert(hash, height);
+    }
+
+    // Accept any size here so we don't need to compensate in partitioning.
+    return !minimal->empty();
+}
+
+} // namespace node
+} // namespace libbitcoin

--- a/src/reservations.cpp
+++ b/src/reservations.cpp
@@ -146,7 +146,7 @@ void reservations::initialize(size_t size)
 {
     // Guard against overflow by capping size.
 
-    const auto max_rows = max_size_t / max_block_request;
+    const size_t max_rows = max_size_t / max_block_request;
     auto rows = std::min(max_rows, size);
 
     // Critical Section

--- a/src/session_block_sync.cpp
+++ b/src/session_block_sync.cpp
@@ -117,7 +117,7 @@ void session_block_sync::handle_connect(const code& ec, channel::ptr channel,
         return;
     }
 
-    log::info(LOG_SESSION)
+    log::debug(LOG_SESSION)
         << "Connected slot (" << row->slot() << ") ["
         << channel->authority() << "]";
 
@@ -160,7 +160,7 @@ void session_block_sync::handle_complete(const code& ec,
     }
 
     log::debug(LOG_SESSION)
-        << "Closed slot (" << row->slot() << ") with error: " << ec.message();
+        << "Closed slot (" << row->slot() << ") " << ec.message();
 
     // There is no failure scenario, we ignore the result code here.
     new_connection(connect, row, handler);

--- a/src/session_header_sync.cpp
+++ b/src/session_header_sync.cpp
@@ -123,7 +123,7 @@ void session_header_sync::handle_connect(const code& ec, channel::ptr channel,
         return;
     }
 
-    log::info(LOG_NETWORK)
+    log::debug(LOG_NETWORK)
         << "Connected to header sync channel [" << channel->authority() << "]";
 
     register_channel(channel,

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -19,12 +19,19 @@
  */
 #include <bitcoin/node/settings.hpp>
 
+#include <thread>
+
 namespace libbitcoin {
 namespace node {
 
+////uint32_t settings::number_of_cores()
+////{
+////    const auto cores = std::thread::hardware_concurrency();
+////    return cores > 0 ? cores : 8;
+////}
+
 settings::settings()
-  : headers_per_second(10000),
-    block_bytes_per_second(100000)
+  : download_connections(8 /* number_of_cores() */)
 {
 }
 

--- a/test/hash_queue.cpp
+++ b/test/hash_queue.cpp
@@ -17,31 +17,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_NODE_SETTINGS_HPP
-#define LIBBITCOIN_NODE_SETTINGS_HPP
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/node.hpp>
 
-#include <cstdint>
-#include <bitcoin/bitcoin.hpp>
-#include <bitcoin/node/define.hpp>
+using namespace bc;
 
-namespace libbitcoin {
-namespace node {
+BOOST_AUTO_TEST_SUITE(hash_queue_tests)
 
-/// Common database configuration settings, properties not thread safe.
-class BCN_API settings
+// Just a basic test to get some coverage output.
+BOOST_AUTO_TEST_CASE(hash_queue_test)
 {
-public:
-    static uint32_t number_of_cores();
+    BOOST_REQUIRE(true);
+}
 
-    settings();
-    settings(bc::settings context);
-
-    /// Properties.
-    uint32_t download_connections;
-    config::endpoint::list peers;
-};
-
-} // namespace node
-} // namespace libbitcoin
-
-#endif
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/reservation.cpp
+++ b/test/reservation.cpp
@@ -17,31 +17,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_NODE_SETTINGS_HPP
-#define LIBBITCOIN_NODE_SETTINGS_HPP
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/node.hpp>
 
-#include <cstdint>
-#include <bitcoin/bitcoin.hpp>
-#include <bitcoin/node/define.hpp>
+using namespace bc;
 
-namespace libbitcoin {
-namespace node {
+BOOST_AUTO_TEST_SUITE(reservation_tests)
 
-/// Common database configuration settings, properties not thread safe.
-class BCN_API settings
+// Just a basic test to get some coverage output.
+BOOST_AUTO_TEST_CASE(reservation_test)
 {
-public:
-    static uint32_t number_of_cores();
+    BOOST_REQUIRE(true);
+}
 
-    settings();
-    settings(bc::settings context);
-
-    /// Properties.
-    uint32_t download_connections;
-    config::endpoint::list peers;
-};
-
-} // namespace node
-} // namespace libbitcoin
-
-#endif
+BOOST_AUTO_TEST_SUITE_END()

--- a/test/reservations.cpp
+++ b/test/reservations.cpp
@@ -17,31 +17,17 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef LIBBITCOIN_NODE_SETTINGS_HPP
-#define LIBBITCOIN_NODE_SETTINGS_HPP
+#include <boost/test/unit_test.hpp>
+#include <bitcoin/node.hpp>
 
-#include <cstdint>
-#include <bitcoin/bitcoin.hpp>
-#include <bitcoin/node/define.hpp>
+using namespace bc;
 
-namespace libbitcoin {
-namespace node {
+BOOST_AUTO_TEST_SUITE(reservations_tests)
 
-/// Common database configuration settings, properties not thread safe.
-class BCN_API settings
+// Just a basic test to get some coverage output.
+BOOST_AUTO_TEST_CASE(reservations_test)
 {
-public:
-    static uint32_t number_of_cores();
+    BOOST_REQUIRE(true);
+}
 
-    settings();
-    settings(bc::settings context);
-
-    /// Properties.
-    uint32_t download_connections;
-    config::endpoint::list peers;
-};
-
-} // namespace node
-} // namespace libbitcoin
-
-#endif
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
This change dynamically load balances across channels and drops channels that deviate from the average block download rate by more than one standard deviation on the negative side.

Channel count remains fixed for the duration of the initial block download, based on node configuration.

Header (first) download is no longer configurable. Instead the single channel uses exponential minimum rate back-off.