### PR TITLE
Regtestnet chain initialization 

### DIFF
--- a/console/executor.cpp
+++ b/console/executor.cpp
@@ -123,7 +123,10 @@ bool executor::do_initchain()
 
         // Unfortunately we are limited to a choice of hardcoded chains.
         auto testnet = (metadata_.configured.network.identifier == 118034699u);
-        const auto genesis = testnet ? block::genesis_testnet() :
+        auto regtest = (metadata_.configured.network.identifier == 3669344250u);
+        const auto genesis =
+            regtest ? block::genesis_regtestnet() :
+            testnet ? block::genesis_testnet() :
             block::genesis_mainnet();
 
         const auto& settings = metadata_.configured.database;


### PR DESCRIPTION
This PR initializes the regtest chain if the configured network identifier is 3669344250

This depends on https://github.com/libbitcoin/libbitcoin/pull/838 and updates https://github.com/libbitcoin/libbitcoin-node/issues/325