### PR TITLE
propagate new bc::settings class

### DIFF
--- a/console/executor.cpp
+++ b/console/executor.cpp
@@ -126,12 +126,15 @@ bool executor::do_initchain()
         // Unfortunately we are limited to a choice of hardcoded chains.
         auto testnet = metadata_.configured.network.identifier == 118034699u;
         auto regtest = metadata_.configured.network.identifier == 3669344250u;
+        const auto& bitcoin_settings = metadata_.configured.bitcoin;
         const auto genesis =
-            regtest ? block::genesis_regtest() :
-            testnet ? block::genesis_testnet() : block::genesis_mainnet();
+            regtest ? block::genesis_regtest(bitcoin_settings) :
+            testnet ? block::genesis_testnet(bitcoin_settings) :
+            block::genesis_mainnet(bitcoin_settings);
 
         const auto& settings = metadata_.configured.database;
-        const auto result = data_base(settings).create(genesis);
+        const auto result =
+            data_base(settings, bitcoin_settings).create(genesis);
 
         LOG_INFO(LOG_NODE) << BN_INITCHAIN_COMPLETE;
         return result;

--- a/include/bitcoin/node/configuration.hpp
+++ b/include/bitcoin/node/configuration.hpp
@@ -59,6 +59,7 @@ public:
     blockchain::settings chain;
     database::settings database;
     network::settings network;
+    libbitcoin::settings bitcoin;
 };
 
 } // namespace node

--- a/include/bitcoin/node/full_node.hpp
+++ b/include/bitcoin/node/full_node.hpp
@@ -77,6 +77,9 @@ public:
     /// Node configuration settings.
     virtual const blockchain::settings& chain_settings() const;
 
+    /// Node configuration settings.
+    virtual const bc::settings& bitcoin_settings() const;
+
     /// Blockchain query interface.
     virtual blockchain::safe_chain& chain();
 
@@ -127,6 +130,7 @@ private:
     const uint32_t protocol_maximum_;
     const node::settings& node_settings_;
     const blockchain::settings& chain_settings_;
+    const bc::settings& bitcoin_settings_;
 };
 
 } // namespace node

--- a/include/bitcoin/node/protocols/protocol_block_in.hpp
+++ b/include/bitcoin/node/protocols/protocol_block_in.hpp
@@ -71,6 +71,7 @@ private:
     const bool blocks_from_peer_;
     const bool require_witness_;
     const bool peer_witness_;
+    const bc::settings& bitcoin_settings_;
 };
 
 } // namespace node

--- a/include/bitcoin/node/protocols/protocol_block_sync.hpp
+++ b/include/bitcoin/node/protocols/protocol_block_sync.hpp
@@ -56,6 +56,7 @@ private:
     blockchain::safe_chain& chain_;
 
     reservation::ptr reservation_;
+    const bc::settings& bitcoin_settings_;
     mutable upgrade_mutex mutex_;
 };
 

--- a/include/bitcoin/node/sessions/session.hpp
+++ b/include/bitcoin/node/sessions/session.hpp
@@ -36,8 +36,9 @@ class BCN_API session
 {
 protected:
     /// Construct an instance.
-    session(full_node& node, bool notify_on_connect)
-      : Session(node, notify_on_connect), node_(node)
+    session(full_node& node, bool notify_on_connect,
+        const bc::settings& bitcoin_settings)
+      : Session(node, notify_on_connect, bitcoin_settings), node_(node)
     {
     }
 

--- a/src/full_node.cpp
+++ b/src/full_node.cpp
@@ -41,14 +41,16 @@ using namespace boost::adaptors;
 using namespace std::placeholders;
 
 full_node::full_node(const configuration& configuration)
-  : p2p(configuration.network),
+  : p2p(configuration.network, configuration.bitcoin),
     reservations_(configuration.network.minimum_connections(),
         configuration.node.maximum_deviation,
         configuration.node.block_latency_seconds),
-    chain_(thread_pool(), configuration.chain, configuration.database),
+    chain_(thread_pool(), configuration.chain, configuration.database,
+        configuration.bitcoin),
     protocol_maximum_(configuration.network.protocol_maximum),
     chain_settings_(configuration.chain),
-    node_settings_(configuration.node)
+    node_settings_(configuration.node),
+    bitcoin_settings_(configuration.bitcoin)
 {
 }
 
@@ -308,6 +310,11 @@ const node::settings& full_node::node_settings() const
 const blockchain::settings& full_node::chain_settings() const
 {
     return chain_settings_;
+}
+
+const bc::settings& full_node::bitcoin_settings() const
+{
+    return bitcoin_settings_;
 }
 
 safe_chain& full_node::chain()

--- a/src/protocols/protocol_block_in.cpp
+++ b/src/protocols/protocol_block_in.cpp
@@ -71,6 +71,7 @@ protocol_block_in::protocol_block_in(full_node& node, channel::ptr channel,
     // Witness must be requested if possibly enforced.
     require_witness_(is_witness(node.network_settings().services)),
     peer_witness_(is_witness(channel->peer_version()->services())),
+    bitcoin_settings_(node.bitcoin_settings()),
     CONSTRUCT_TRACK(protocol_block_in)
 {
 }

--- a/src/protocols/protocol_block_sync.cpp
+++ b/src/protocols/protocol_block_sync.cpp
@@ -48,6 +48,7 @@ protocol_block_sync::protocol_block_sync(full_node& node, channel::ptr channel,
   : protocol_timer(node, channel, true, NAME),
     chain_(chain),
     reservation_(node.get_reservation()),
+    bitcoin_settings_(node.bitcoin_settings()),
     CONSTRUCT_TRACK(protocol_block_sync)
 {
 }

--- a/src/sessions/session_inbound.cpp
+++ b/src/sessions/session_inbound.cpp
@@ -36,7 +36,8 @@ using namespace bc::network;
 using namespace std::placeholders;
 
 session_inbound::session_inbound(full_node& network, safe_chain& chain)
-  : session<network::session_inbound>(network, true),
+  : session<network::session_inbound>(network, true,
+        network.bitcoin_settings()),
     chain_(chain),
     CONSTRUCT_TRACK(node::session_inbound)
 {

--- a/src/sessions/session_manual.cpp
+++ b/src/sessions/session_manual.cpp
@@ -36,7 +36,8 @@ using namespace bc::network;
 using namespace std::placeholders;
 
 session_manual::session_manual(full_node& network, safe_chain& chain)
-  : session<network::session_manual>(network, true),
+    : session<network::session_manual>(network, true,
+        network.bitcoin_settings()),
     chain_(chain),
     CONSTRUCT_TRACK(node::session_manual)
 {

--- a/src/sessions/session_outbound.cpp
+++ b/src/sessions/session_outbound.cpp
@@ -36,7 +36,8 @@ using namespace bc::network;
 using namespace std::placeholders;
 
 session_outbound::session_outbound(full_node& network, safe_chain& chain)
-  : session<network::session_outbound>(network, true),
+  : session<network::session_outbound>(network, true,
+        network.bitcoin_settings()),
     chain_(chain),
     CONSTRUCT_TRACK(node::session_outbound)
 {

--- a/test/utility.cpp
+++ b/test/utility.cpp
@@ -60,7 +60,8 @@ message::headers::ptr message_factory(size_t count,
 
     for (size_t height = 0; height < count; ++height)
     {
-        const header current_header{ 0, previous_hash, {}, 0, 0, 0 };
+        const header current_header{ 0, previous_hash, {}, 0, 0, 0,
+            bc::settings() };
         elements.push_back(current_header);
         previous_hash = current_header.hash();
     }


### PR DESCRIPTION
I'm planning to extend the parser once all constants have been moved into `bc::settings`.