### PR TITLE
Corrected flag inversion for candidate/confirmed

### DIFF
--- a/src/full_node.cpp
+++ b/src/full_node.cpp
@@ -115,7 +115,7 @@ void full_node::handle_running(const code& ec, result_handler handler)
     }
 
     checkpoint confirmed;
-    if (!chain_.get_top(confirmed, true))
+    if (!chain_.get_top(confirmed, false))
     {
         LOG_ERROR(LOG_NODE)
             << "The block chain is corrupt.";


### PR DESCRIPTION
(this worked for me to get libbitcoin-node v4 launching and starting to do p2p despite having no candidates)