### PR TITLE
added local re-build

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -729,6 +729,7 @@ build_from_travis()
 #==============================================================================
 build_all()
 {
+ if [ ! -d "$BUILD_DIR/libbitcoin-node" ]; then
     build_from_tarball_boost $BOOST_URL $BOOST_ARCHIVE bzip2 . $PARALLEL "$BUILD_BOOST" "${BOOST_OPTIONS[@]}"
     build_from_github libbitcoin secp256k1 version5 $PARALLEL ${SECP256K1_OPTIONS[@]} "$@"
     build_from_github libbitcoin libbitcoin master $PARALLEL ${BITCOIN_OPTIONS[@]} "$@"
@@ -737,6 +738,9 @@ build_all()
     build_from_github libbitcoin libbitcoin-blockchain master $PARALLEL ${BITCOIN_BLOCKCHAIN_OPTIONS[@]} "$@"
     build_from_github libbitcoin libbitcoin-network master $PARALLEL ${BITCOIN_NETWORK_OPTIONS[@]} "$@"
     build_from_travis libbitcoin libbitcoin-node master $PARALLEL ${BITCOIN_NODE_OPTIONS[@]} "$@"
+ else
+    build_from_local "local re-build" $PARALLEL ${BITCOIN_OPTIONS[@]} "$@"
+ fi
 }
 
 
@@ -746,9 +750,11 @@ if [[ $DISPLAY_HELP ]]; then
     display_help
 else
     display_configuration
+    if [ ! -d "$BUILD_DIR" ]; then
     create_directory "$BUILD_DIR"
     push_directory "$BUILD_DIR"
     initialize_git
     pop_directory
+    fi
     time build_all "${CONFIGURE_OPTIONS[@]}"
 fi


### PR DESCRIPTION
this should be compatible with anything Travis does once with a fresh vm, but it might break Travis build testing if he is expected to get a new copy of the github repository every build and if for some reason multiple builds get done in series on the same Travis vm.

a local re-build saves me a lot of time, and this way I get to use ./install.sh with my --prefix and without downloading and re-building everything every time, and without worrying about whether stuff got copied into the right place based on my --prefix

if this local re-build approach to this problem looks good then I'll submit pull requests to each repository making this same change to each respective install.sh file.