### PR TITLE
Revert "propagate new bc::settings class"

### DIFF
--- a/console/executor.cpp
+++ b/console/executor.cpp
@@ -124,8 +124,8 @@ bool executor::do_initchain()
         LOG_INFO(LOG_NODE) << format(BN_INITIALIZING_CHAIN) % directory;
 
         const auto& bitcoin_settings = metadata_.configured.bitcoin;
-        const auto result = data_base(metadata_.configured.database,
-            bitcoin_settings).create(bitcoin_settings.genesis_block);
+        const auto result = data_base(metadata_.configured.database)
+            .create(bitcoin_settings.genesis_block);
 
         LOG_INFO(LOG_NODE) << BN_INITCHAIN_COMPLETE;
         return result;

--- a/include/bitcoin/node/full_node.hpp
+++ b/include/bitcoin/node/full_node.hpp
@@ -77,9 +77,6 @@ public:
     /// Node configuration settings.
     virtual const blockchain::settings& chain_settings() const;
 
-    /// Node configuration settings.
-    virtual const bc::settings& bitcoin_settings() const;
-
     /// Blockchain query interface.
     virtual blockchain::safe_chain& chain();
 
@@ -129,7 +126,6 @@ private:
     const uint32_t protocol_maximum_;
     const node::settings& node_settings_;
     const blockchain::settings& chain_settings_;
-    const bc::settings& bitcoin_settings_;
 };
 
 } // namespace node

--- a/include/bitcoin/node/protocols/protocol_block_in.hpp
+++ b/include/bitcoin/node/protocols/protocol_block_in.hpp
@@ -75,7 +75,6 @@ private:
     const bool blocks_from_peer_;
     const bool require_witness_;
     const bool peer_witness_;
-    const bc::settings& bitcoin_settings_;
 };
 
 } // namespace node

--- a/include/bitcoin/node/protocols/protocol_block_sync.hpp
+++ b/include/bitcoin/node/protocols/protocol_block_sync.hpp
@@ -60,7 +60,6 @@ private:
     blockchain::safe_chain& chain_;
 
     reservation::ptr reservation_;
-    const bc::settings& bitcoin_settings_;
     mutable upgrade_mutex mutex_;
 };
 

--- a/include/bitcoin/node/sessions/session.hpp
+++ b/include/bitcoin/node/sessions/session.hpp
@@ -36,9 +36,8 @@ class BCN_API session
 {
 protected:
     /// Construct an instance.
-    session(full_node& node, bool notify_on_connect,
-        const bc::settings& bitcoin_settings)
-      : Session(node, notify_on_connect, bitcoin_settings), node_(node)
+    session(full_node& node, bool notify_on_connect)
+      : Session(node, notify_on_connect), node_(node)
     {
     }
 

--- a/src/full_node.cpp
+++ b/src/full_node.cpp
@@ -41,7 +41,7 @@ using namespace boost::adaptors;
 using namespace std::placeholders;
 
 full_node::full_node(const configuration& configuration)
-  : p2p(configuration.network, configuration.bitcoin),
+  : p2p(configuration.network),
     reservations_(configuration.network.minimum_connections(),
         configuration.node.maximum_deviation,
         configuration.node.block_latency_seconds),
@@ -49,8 +49,7 @@ full_node::full_node(const configuration& configuration)
         configuration.bitcoin),
     protocol_maximum_(configuration.network.protocol_maximum),
     chain_settings_(configuration.chain),
-    node_settings_(configuration.node),
-    bitcoin_settings_(configuration.bitcoin)
+    node_settings_(configuration.node)
 {
 }
 
@@ -312,11 +311,6 @@ const node::settings& full_node::node_settings() const
 const blockchain::settings& full_node::chain_settings() const
 {
     return chain_settings_;
-}
-
-const bc::settings& full_node::bitcoin_settings() const
-{
-    return bitcoin_settings_;
 }
 
 safe_chain& full_node::chain()

--- a/src/protocols/protocol_block_in.cpp
+++ b/src/protocols/protocol_block_in.cpp
@@ -71,7 +71,6 @@ protocol_block_in::protocol_block_in(full_node& node, channel::ptr channel,
     // Witness must be requested if possibly enforced.
     require_witness_(is_witness(node.network_settings().services)),
     peer_witness_(is_witness(channel->peer_version()->services())),
-    bitcoin_settings_(node.bitcoin_settings()),
     CONSTRUCT_TRACK(protocol_block_in)
 {
 }

--- a/src/protocols/protocol_block_sync.cpp
+++ b/src/protocols/protocol_block_sync.cpp
@@ -48,7 +48,6 @@ protocol_block_sync::protocol_block_sync(full_node& node, channel::ptr channel,
   : protocol_timer(node, channel, true, NAME),
     chain_(chain),
     reservation_(node.get_reservation()),
-    bitcoin_settings_(node.bitcoin_settings()),
     CONSTRUCT_TRACK(protocol_block_sync)
 {
 }

--- a/src/sessions/session_inbound.cpp
+++ b/src/sessions/session_inbound.cpp
@@ -36,8 +36,7 @@ using namespace bc::network;
 using namespace std::placeholders;
 
 session_inbound::session_inbound(full_node& network, safe_chain& chain)
-  : session<network::session_inbound>(network, true,
-        network.bitcoin_settings()),
+  : session<network::session_inbound>(network, true),
     chain_(chain),
     CONSTRUCT_TRACK(node::session_inbound)
 {

--- a/src/sessions/session_manual.cpp
+++ b/src/sessions/session_manual.cpp
@@ -36,8 +36,7 @@ using namespace bc::network;
 using namespace std::placeholders;
 
 session_manual::session_manual(full_node& network, safe_chain& chain)
-    : session<network::session_manual>(network, true,
-        network.bitcoin_settings()),
+  : session<network::session_manual>(network, true),
     chain_(chain),
     CONSTRUCT_TRACK(node::session_manual)
 {

--- a/src/sessions/session_outbound.cpp
+++ b/src/sessions/session_outbound.cpp
@@ -36,8 +36,7 @@ using namespace bc::network;
 using namespace std::placeholders;
 
 session_outbound::session_outbound(full_node& network, safe_chain& chain)
-  : session<network::session_outbound>(network, true,
-        network.bitcoin_settings()),
+  : session<network::session_outbound>(network, true),
     chain_(chain),
     CONSTRUCT_TRACK(node::session_outbound)
 {


### PR DESCRIPTION
This reverts commit 4ff5768fe663698d43de9c8d3b009a20f1330149.

Reason: https://github.com/libbitcoin/libbitcoin/pull/1013