### PR TITLE
Hide subscr key in protocol base, use notity_one for starve.

### DIFF
--- a/include/bitcoin/node/chase.hpp
+++ b/include/bitcoin/node/chase.hpp
@@ -45,7 +45,7 @@ enum class chase
     /// Issued by 'full_node' and handled by 'observer'.
     suspend,
 
-    /// Channel starved for block download identifiers (channel_t).
+    /// Channel starved for work (object_t).
     /// Issued by 'block_in_31800' and handled by 'session_outbound'.
     starved,
 
@@ -61,7 +61,7 @@ enum class chase
     /// Issued by 'check' and handled by 'block_in_31800'.
     purge,
 
-    /// Channels (all) directed to write hash count to the log (count_t).
+    /// Channels (all) directed to write work count to the log (count_t).
     /// Issued by 'executore' and handled by 'block_in_31800'.
     report,
 

--- a/include/bitcoin/node/define.hpp
+++ b/include/bitcoin/node/define.hpp
@@ -77,6 +77,7 @@ typedef event_subscriber::completer event_completer;
 using count_t = size_t;
 using height_t = size_t;
 using channel_t = uint64_t;
+using object_t = object_key;
 using header_t = database::header_link::integer;
 using transaction_t = database::tx_link::integer;
 

--- a/include/bitcoin/node/protocols/protocol.hpp
+++ b/include/bitcoin/node/protocols/protocol.hpp
@@ -78,7 +78,7 @@ protected:
     /// Events.
     /// -----------------------------------------------------------------------
 
-    /// Subscribe to chaser events.
+    /// Subscribe to chaser events (only once).
     virtual void subscribe_events(event_notifier&& handler,
         event_completer&& complete) NOEXCEPT;
 
@@ -87,7 +87,10 @@ protected:
         event_value value) NOEXCEPT;
 
     /// Unsubscribe from chaser events.
-    virtual void unsubscribe_events(object_key key) NOEXCEPT;
+    virtual void unsubscribe_events() NOEXCEPT;
+
+    /// Get the subscription key (for notify_one).
+    virtual object_key events_key() const NOEXCEPT;
 
     /// Properties.
     /// -----------------------------------------------------------------------
@@ -102,8 +105,14 @@ protected:
     virtual bool is_current() const NOEXCEPT;
 
 private:
+    void handle_subscribe(const code& ec, object_key key,
+        const event_completer& complete) NOEXCEPT;
+
     // This is thread safe.
     const session::ptr session_;
+
+    // This is protected by singular subscription.
+    object_key key_{};
 };
 
 } // namespace node

--- a/include/bitcoin/node/protocols/protocol_block_in_31800.hpp
+++ b/include/bitcoin/node/protocols/protocol_block_in_31800.hpp
@@ -84,7 +84,7 @@ private:
     void restore(const map_ptr& map) NOEXCEPT;
     void handle_put_hashes(const code& ec, size_t count) NOEXCEPT;
     void handle_get_hashes(const code& ec, const map_ptr& map) NOEXCEPT;
-    void do_complete_event(const code& ec, object_key key) NOEXCEPT;
+    void do_complete_event(const code& ec) NOEXCEPT;
 
     // This is thread safe.
     const network::messages::inventory::type_id block_type_;

--- a/include/bitcoin/node/protocols/protocol_block_in_31800.hpp
+++ b/include/bitcoin/node/protocols/protocol_block_in_31800.hpp
@@ -89,9 +89,8 @@ private:
     // This is thread safe.
     const network::messages::inventory::type_id block_type_;
 
-    // These are protected by strand.
+    // This is protected by strand.
     map_ptr map_;
-    object_key key_{};
 };
 
 } // namespace node

--- a/include/bitcoin/node/protocols/protocol_observer.hpp
+++ b/include/bitcoin/node/protocols/protocol_observer.hpp
@@ -54,7 +54,7 @@ protected:
         event_value value) NOEXCEPT;
 
 private:
-    void do_complete_event(const code& ec, object_key key) NOEXCEPT;
+    void do_complete_event(const code& e) NOEXCEPT;
 
     // This is protected by strand.
     object_key key_{};

--- a/include/bitcoin/node/protocols/protocol_observer.hpp
+++ b/include/bitcoin/node/protocols/protocol_observer.hpp
@@ -55,9 +55,6 @@ protected:
 
 private:
     void do_complete_event(const code& e) NOEXCEPT;
-
-    // This is protected by strand.
-    object_key key_{};
 };
 
 } // namespace node

--- a/include/bitcoin/node/sessions/session_outbound.hpp
+++ b/include/bitcoin/node/sessions/session_outbound.hpp
@@ -37,14 +37,14 @@ public:
     session_outbound(full_node& node, uint64_t identifier) NOEXCEPT;
 
     void start(network::result_handler&& handler) NOEXCEPT override;
-    void performance(uint64_t channel, uint64_t speed,
+    void performance(object_key channel, uint64_t speed,
         network::result_handler&& handler) NOEXCEPT override;
 
 protected:
     virtual bool handle_event(const code& ec, chase event_,
         event_value value) NOEXCEPT;
-    virtual void split(channel_t self) NOEXCEPT;
-    virtual void do_performance(uint64_t channel, uint64_t speed,
+    virtual void split(object_t self) NOEXCEPT;
+    virtual void do_performance(object_key channel, uint64_t speed,
         const network::result_handler& handler) NOEXCEPT;
 
 private:
@@ -54,7 +54,7 @@ private:
     const float allowed_deviation_;
 
     // This is protected by strand.
-    std::unordered_map<uint64_t, double> speeds_{};
+    std::unordered_map<object_key, double> speeds_{};
 };
 
 } // namespace node

--- a/src/chasers/chaser_confirm.cpp
+++ b/src/chasers/chaser_confirm.cpp
@@ -278,6 +278,7 @@ bool chaser_confirm::set_confirmed(header_t link, height_t height) NOEXCEPT
     if (!query.push_confirmed(link))
         return false;
 
+    // Could just tap into organized, but it uses link vs. height.
     if (is_zero(height % config().node.snapshot_interval_()))
         notify(error::success, chase::snapshot, height);
 

--- a/src/chasers/chaser_snapshot.cpp
+++ b/src/chasers/chaser_snapshot.cpp
@@ -87,10 +87,10 @@ void chaser_snapshot::do_snapshot(size_t height) NOEXCEPT
 
     if (const auto ec = snapshot([&](auto, auto) NOEXCEPT
     {
-        LOGN("SNAPSHOT PROGRESS: " << height);
+        LOGA("SNAPSHOT PROGRESS: " << height);
     }))
     {
-        LOGN("SNAPSHOT ERROR: " << ec.message());
+        LOGA("SNAPSHOT ERROR: " << ec.message());
     }
 }
 

--- a/src/protocols/protocol_block_in_31800.cpp
+++ b/src/protocols/protocol_block_in_31800.cpp
@@ -103,10 +103,10 @@ bool protocol_block_in_31800::is_idle() const NOEXCEPT
     return map_->empty();
 }
 
-bool protocol_block_in_31800::handle_event(const code&,
+bool protocol_block_in_31800::handle_event(const code& ec,
     chase event_, event_value value) NOEXCEPT
 {
-    if (stopped())
+    if (stopped(ec))
         return false;
 
     switch (event_)

--- a/src/protocols/protocol_observer.cpp
+++ b/src/protocols/protocol_observer.cpp
@@ -47,20 +47,18 @@ void protocol_observer::start() NOEXCEPT
 // protected
 void protocol_observer::complete_event(const code& ec, object_key key) NOEXCEPT
 {
-    POST(do_complete_event, ec, key);
+    POST(do_complete_event, ec);
 }
 
 // private
-void protocol_observer::do_complete_event(const code&,
-    object_key key) NOEXCEPT
+void protocol_observer::do_complete_event(const code& ec) NOEXCEPT
 {
     BC_ASSERT(stranded());
-    key_ = key;
 
     // stopped() is true before stopping() is called (by base).
-    if (stopped())
+    if (stopped(ec))
     {
-        unsubscribe_events(key_);
+        unsubscribe_events();
         return;
     }
 }
@@ -69,7 +67,7 @@ void protocol_observer::do_complete_event(const code&,
 void protocol_observer::stopping(const code& ec) NOEXCEPT
 {
     BC_ASSERT(stranded());
-    unsubscribe_events(key_);
+    unsubscribe_events();
     protocol::stopping(ec);
 }
 

--- a/src/protocols/protocol_observer.cpp
+++ b/src/protocols/protocol_observer.cpp
@@ -45,7 +45,7 @@ void protocol_observer::start() NOEXCEPT
 }
 
 // protected
-void protocol_observer::complete_event(const code& ec, object_key key) NOEXCEPT
+void protocol_observer::complete_event(const code& ec, object_key) NOEXCEPT
 {
     POST(do_complete_event, ec);
 }
@@ -71,10 +71,10 @@ void protocol_observer::stopping(const code& ec) NOEXCEPT
     protocol::stopping(ec);
 }
 
-bool protocol_observer::handle_event(const code&, chase event_,
+bool protocol_observer::handle_event(const code& ec, chase event_,
     event_value) NOEXCEPT
 {
-    if (stopped())
+    if (stopped(ec))
         return false;
 
     switch (event_)

--- a/src/sessions/session_outbound.cpp
+++ b/src/sessions/session_outbound.cpp
@@ -82,7 +82,7 @@ bool session_outbound::handle_event(const code&,
         case chase::starved:
         {
             // When a channel becomes starved notify other(s) to split work.
-            split(possible_narrow_cast<channel_t>(value));
+            split(possible_narrow_cast<object_t>(value));
             break;
         }
         case chase::stop:
@@ -98,7 +98,9 @@ bool session_outbound::handle_event(const code&,
     return true;
 }
 
-void session_outbound::split(channel_t self) NOEXCEPT
+// object_key is used instead of channel identifier because the event
+// subscriber supports objects other than channels.
+void session_outbound::split(object_t self) NOEXCEPT
 {
     BC_ASSERT(stranded());
 
@@ -120,8 +122,7 @@ void session_outbound::split(channel_t self) NOEXCEPT
         const auto channel = slowest->first;
         speeds_.erase(slowest);
 
-        // TODO: use notify_one and subscription key to identify channel.
-        node::session::notify(error::success, chase::split, channel);
+        node::session::notify_one(self, error::success, chase::split, channel);
         return;
     }
 


### PR DESCRIPTION
This is a performance optimization whereby only the targeted message handler is invoked.