### PR TITLE
handle unknown estimator mode

### DIFF
--- a/src/estimator.cpp
+++ b/src/estimator.cpp
@@ -76,6 +76,10 @@ uint64_t estimator::estimate(size_t target, mode mode) const NOEXCEPT
             estimate = std::max({ fee1, fee2, fee3 });
             break;
         }
+        case mode::unknown:
+        {
+            break;
+        }
     }
 
     return estimate;

--- a/test/estimator.cpp
+++ b/test/estimator.cpp
@@ -101,6 +101,16 @@ BOOST_AUTO_TEST_CASE(estimator__top_height__non_default__expected)
     BOOST_REQUIRE_EQUAL(instance->top_height(), 42u);
 }
 
+// estimate
+
+BOOST_AUTO_TEST_CASE(estimator__estimate__unknown_mode__max_uint64)
+{
+    const auto instance = acessor::create();
+    const auto estimate = instance->estimate(0u, estimator::mode::unknown);
+
+    BOOST_REQUIRE_EQUAL(estimate, max_uint64);
+}
+
 // initialize
 
 BOOST_AUTO_TEST_CASE(estimator__initialize__empty__true_height_unchanged)


### PR DESCRIPTION
return the estimator failure sentinel for mode::unknown instead of leaving the enum case implicit. makes estimate() exhaustive over its mode domain and documents the expected result with a focused unit test.

discovered via a clang warning.