### PR TITLE
Fix get_client_filters livelock in protocol_filter_out_70015

### DIFF
--- a/src/protocols/protocol_filter_out_70015.cpp
+++ b/src/protocols/protocol_filter_out_70015.cpp
@@ -220,8 +220,8 @@ bool protocol_filter_out_70015::handle_receive_get_filters(const code& ec,
         return false;
     }
 
-    span<milliseconds>(events::ancestry_msecs, start);
     // Post so the completion resubscribe runs outside the current notify().
+    span<milliseconds>(events::ancestry_msecs, start);
     POST(send_filter, error::success, ancestry);
     return false;
 }

--- a/src/protocols/protocol_filter_out_70015.cpp
+++ b/src/protocols/protocol_filter_out_70015.cpp
@@ -221,7 +221,8 @@ bool protocol_filter_out_70015::handle_receive_get_filters(const code& ec,
     }
 
     span<milliseconds>(events::ancestry_msecs, start);
-    send_filter(error::success, ancestry);
+    // Post so the completion resubscribe runs outside the current notify().
+    POST(send_filter, error::success, ancestry);
     return false;
 }
 


### PR DESCRIPTION
## Bug

`handle_receive_get_filters` returns `false` (drop), and `send_filter`, on an empty ancestry, resubscribes via `SUBSCRIBE_CHANNEL` inside the notify cycle, re-entering the handler for the same in-flight message. This is the bip157 compact-filter sibling of the `protocol_transaction_out_106` `get_data` livelock (#1070) -- the identical resubscribe-during-notify pattern.

## Reachability

Config-gated: `protocol_filter_out_70015` attaches only when the node advertises `node_client_filters` *and* the peer negotiates bip157, and a default node advertises neither (`protocol_maximum` caps at bip130, filters off). It becomes reachable only when the node is configured as a compact-filter server (`[peer] protocol_maximum = 70015` plus the `node_client_filters` service bit and `filter_bk_buckets > 0`).

**Now reproduced live under that config** (previously latent / inspection-only): on a filter-indexed testnet3 store, a single-block `getcfilters` (`start_height == stop` height) yields count 0 -> empty ancestry -> the loop. Unpatched spins CPU hot; patched holds ~0% and still serves filters. (The count-0-for-a-single-block result is a separate off-by-one, handled independently -- this PR is only the livelock.)

## Fix (revised per review)

Same as #1070: keep `return false` (the drop is backpressure) and the resubscribe; wrap the send in `POST(send_filter, ...)` so it runs outside `notify`. The other two handlers in this protocol (`get_filter_checkpoint`, `get_filter_headers`) already `return true` and are unaffected.
